### PR TITLE
Feat/typecheck

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,8 +9,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
       - run: npm install
-      # TODO: tsc
-      - name: lint
-        run: npm run lint
-      - name: test
-        run: npm run test
+      - name: check
+        run: npm run check

--- a/admin/package.json
+++ b/admin/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "format": "biome format --write .",
     "test": "vitest run --passWithNoTests"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "typecheck": "tsc --noEmit",
     "lint": "biome check .",
     "format": "biome check --write .",
     "test": "vitest run --passWithNoTests",

--- a/frontend/src/ThemeContext.tsx
+++ b/frontend/src/ThemeContext.tsx
@@ -7,7 +7,6 @@ import {
 } from "react";
 import { apiClient } from "./services/api/apiClient";
 import { ApiErrorType } from "./services/api/apiError";
-import type { Theme } from "./types";
 
 interface ThemeContextType {
   defaultThemeId: string | null;

--- a/frontend/src/components/chat/FloatingChat.tsx
+++ b/frontend/src/components/chat/FloatingChat.tsx
@@ -1,11 +1,5 @@
-import React, {
-  useState,
-  useEffect,
-  useRef,
-  useImperativeHandle,
-  forwardRef,
-} from "react";
-import { ExtendedMessage, type MessageType } from "../../types";
+import { forwardRef, useImperativeHandle, useState } from "react";
+import { type MessageType } from "../../types";
 import { ChatProvider, useChat } from "./ChatProvider";
 import { ChatSheet } from "./ChatSheet";
 import { FloatingChatButton } from "./FloatingChatButton";

--- a/idea-discussion/backend/package.json
+++ b/idea-discussion/backend/package.json
@@ -7,6 +7,7 @@
     "test": "vitest run --passWithNoTests",
     "start": "node server.js",
     "dev": "nodemon server.js",
+    "typecheck": "echo 'typecheck is not supported in this package'",
     "lint": "biome check .",
     "format": "biome check --write .",
     "migrate-themes": "node scripts/migrateToThemes.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10342,6 +10342,7 @@
         "zustand": "^5.0.3"
       },
       "devDependencies": {
+        "@biomejs/biome": "^1.9.4",
         "@tailwindcss/typography": "^0.5.16",
         "@types/node": "^22.14.1",
         "@types/react": "^19.0.10",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "frontend"
   ],
   "scripts": {
+    "check": "npm run lint && npm run typecheck && npm run test",
     "test": "npm run test -ws",
+    "typecheck": "npm run typecheck -ws",
     "lint": "biome check .",
     "format": "biome check --write ."
   }

--- a/policy-edit/backend/package.json
+++ b/policy-edit/backend/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "build:mcp": "cd ../mcp && npm run build",
     "start": "node build/index.js",
+    "typecheck": "tsc --noEmit",
     "dev": "nodemon",
     "lint": "biome check .",
     "format": "biome check --write .",

--- a/policy-edit/frontend/package.json
+++ b/policy-edit/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "biome check .",
+    "typecheck": "tsc --noEmit",
     "format": "biome check --write .",
     "test": "vitest run --passWithNoTests",
     "preview": "vite preview"

--- a/policy-edit/mcp/package.json
+++ b/policy-edit/mcp/package.json
@@ -7,6 +7,7 @@
     "build": "tsc",
     "start": "node dist/main.js",
     "test": "vitest run --passWithNoTests",
+    "typecheck": "tsc --noEmit",
     "dev": "nodemon --watch src --exec \"node --loader ts-node/esm src/main.ts\" | pino-pretty",
     "lint": "biome check .",
     "format": "biome check --write ."


### PR DESCRIPTION
# 変更の概要
- npm run typecheck を追加
    - idea-discussion-backend だけは ts 未対応
- typecheck のエラーを修正
- ci に typecheck を追加

# 関連Issue
https://github.com/digitaldemocracy2030/idobata/issues/88

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました
