### PR TITLE
Update: frontendでもmongoに合わせて_idを使うようにした

### DIFF
--- a/frontend/src/ThemeContext.tsx
+++ b/frontend/src/ThemeContext.tsx
@@ -63,8 +63,8 @@ export const ThemeProvider = ({ children }: ThemeProviderProps) => {
       }
 
       const defaultTheme = result.value;
-      setDefaultThemeId(defaultTheme.id);
-      localStorage.setItem("defaultThemeId", defaultTheme.id);
+      setDefaultThemeId(defaultTheme._id);
+      localStorage.setItem("defaultThemeId", defaultTheme._id);
       setError(null);
 
       setIsLoading(false);

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -53,8 +53,8 @@ function AppLayout() {
         const themeResult = await apiClient.getDefaultTheme();
         if (themeResult.isOk()) {
           const defaultTheme = themeResult.value;
-          setCurrentThemeId(defaultTheme.id);
-          localStorage.setItem("currentThemeId", defaultTheme.id);
+          setCurrentThemeId(defaultTheme._id);
+          localStorage.setItem("currentThemeId", defaultTheme._id);
         } else {
           throw new Error(
             `テーマの取得に失敗しました: ${themeResult.error.message}`
@@ -277,8 +277,8 @@ function AppLayout() {
           const themeResult = await apiClient.getDefaultTheme();
           if (themeResult.isOk()) {
             const defaultTheme = themeResult.value;
-            setCurrentThemeId(defaultTheme.id);
-            localStorage.setItem("currentThemeId", defaultTheme.id);
+            setCurrentThemeId(defaultTheme._id);
+            localStorage.setItem("currentThemeId", defaultTheme._id);
           }
         } catch (error) {
           console.error("Failed to load default theme:", error);

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -66,8 +66,8 @@ const Header = () => {
                 !error &&
                 themes.map((theme) => (
                   <NavigationRouterLink
-                    key={theme.id}
-                    to={`/themes/${theme.id}`}
+                    key={theme._id}
+                    to={`/themes/${theme._id}`}
                     className="text-sm py-2 px-4 hover:bg-purple-50 rounded-md"
                   >
                     {theme.title}

--- a/frontend/src/components/theme/ThemeDetailTemplate.tsx
+++ b/frontend/src/components/theme/ThemeDetailTemplate.tsx
@@ -6,7 +6,7 @@ import KeyQuestionCard from "./KeyQuestionCard";
 
 interface ThemeDetailTemplateProps {
   theme: {
-    id: string;
+    _id: string;
     title: string;
     description: string;
   };
@@ -47,7 +47,7 @@ const ThemeDetailTemplate = ({
   const breadcrumbItems = [
     { label: "TOP", href: "/" },
     { label: "テーマ一覧", href: "/themes" },
-    { label: theme.title, href: `/themes/${theme.id}` },
+    { label: theme.title, href: `/themes/${theme._id}` },
   ];
 
   return (

--- a/frontend/src/pages/ThemeDetail.tsx
+++ b/frontend/src/pages/ThemeDetail.tsx
@@ -14,7 +14,7 @@ const ThemeDetail = () => {
 
   // モックデータ
   const mockThemeData = {
-    id: themeId || "",
+    _id: themeId || "",
     title: "若者の雇用とキャリア支援",
     description:
       "若者の雇用不安や将来への不安を解消し、安心してキャリアを築ける社会の実現について議論します。新卒一括採用や終身雇用の変化、フリーランスの増加など、働き方の多様化に対応した支援策を考えます。",
@@ -101,7 +101,7 @@ const ThemeDetail = () => {
         }
       : {
           theme: {
-            id: themeDetail?.theme?.id ?? "",
+            _id: themeDetail?.theme?._id ?? "",
             title: themeDetail?.theme?.title ?? "",
             description: themeDetail?.theme?.description ?? "",
           },

--- a/frontend/src/pages/Themes.tsx
+++ b/frontend/src/pages/Themes.tsx
@@ -58,8 +58,8 @@ const Themes = () => {
         <div className="grid grid-cols-1 gap-4 mb-12">
           {themes.map((theme) => (
             <ThemeCard
-              key={theme.id}
-              id={theme.id}
+              key={theme._id}
+              id={theme._id}
               title={theme.title}
               description={theme.description || ""}
               keyQuestionCount={theme.keyQuestionCount || 0}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -82,7 +82,7 @@ export interface QuestionDetails {
 export type TabType = "questions" | "problems" | "solutions" | "policies";
 
 export interface Theme {
-  id: string;
+  _id: string;
   title: string;
   description?: string;
   slug: string;

--- a/idea-discussion/backend/controllers/themeController.js
+++ b/idea-discussion/backend/controllers/themeController.js
@@ -28,7 +28,7 @@ export const getAllThemes = async (req, res) => {
 
       // 拡張されたテーマ情報を追加
       enhancedThemes.push({
-        id: theme._id,
+        _id: theme._id,
         title: theme.title,
         description: theme.description || "",
         slug: theme.slug,


### PR DESCRIPTION
# 変更の概要
* mongoではデフォルトで_idを使う
* 既存実装もある中、idに毎回変更するのはコストが高いので、このPJでは既存実装に合わせてfrontendでも_idを使うようにした
* 型もあるし、それほど後戻り不可能な意思決定ではない認識

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
