### PR TITLE
Add JWT_SECRET and JWT_EXPIRES_IN in .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -15,6 +15,9 @@ GITHUB_TARGET_OWNER=your_github_username_or_org_here
 GITHUB_TARGET_REPO=your_target_repository_name_here
 GITHUB_BASE_BRANCH=main # Or your default branch
 
+# JWT Settings (Required for Authentication)
+JWT_SECRET=generate_a_strong_secret_key_here # e.g., use openssl rand -hex 32
+JWT_EXPIRES_IN=1d # e.g., 1d, 7d, 30m
 # CORS Settings (Adjust if your frontend runs on a different port during development)
 # CORS_ORIGIN is often handled by backend logic based on NODE_ENV, but can be set explicitly if needed
 # CORS_ORIGIN=http://localhost:5174

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       - GITHUB_BASE_BRANCH=${GITHUB_BASE_BRANCH}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
       - IDEA_CORS_ORIGIN=${IDEA_CORS_ORIGIN}
+      - JWT_SECRET=${JWT_SECRET} # Pass JWT secret from .env
+      - JWT_EXPIRES_IN=${JWT_EXPIRES_IN:-1d} # Pass expiration, default to 1 day
     command: npm run dev # Command defined in Dockerfile.dev
 
   # --- policy-edit ---


### PR DESCRIPTION
# 変更の概要
JWT_SECRETなどが.envに入っておらず、adminのログイン/JWT発行が動作しなかった。
そのため、2つの変数を.env.templateに追加し、docker-compose.ymlも合わせて修正。

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
