### PR TITLE
outline button の色がきつかったので調整した

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -110,7 +110,6 @@ const Header = () => {
                 <div className="flex mt-4 px-4">
                   <Button
                     variant="outline"
-                    size="sm"
                     onClick={toggleMockMode}
                     className="text-xs"
                   >
@@ -139,9 +138,8 @@ const Header = () => {
             <div className="flex items-center gap-1">
               <Button
                 variant="outline"
-                size="sm"
                 onClick={toggleMockMode}
-                className="text-xs hidden sm:inline"
+                className="text-xs"
               >
                 {isMockMode
                   ? "モックモードを解除しトップへ"

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -40,7 +40,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
               variant === "default",
             "bg-destructive text-destructive-foreground hover:bg-destructive/90":
               variant === "destructive",
-            "border border-input bg-background hover:bg-accent hover:text-accent-foreground":
+            "border border-input bg-background hover:bg-gray-50":
               variant === "outline",
             "bg-secondary text-secondary-foreground hover:bg-secondary/80":
               variant === "secondary",


### PR DESCRIPTION
# 変更の概要

outline button をマウスオーバーするとアクセントカラーになっていて変だったので無難な色に変更した

# スクリーンショット

![Screenshot 2025-05-05 at 13 21 25](https://github.com/user-attachments/assets/6092867e-ad3d-4679-97f8-0acfe9fce69d)

![Screenshot 2025-05-05 at 13 21 34](https://github.com/user-attachments/assets/44e1ff53-ed54-413b-9b37-d7cee7320ffe)

# 変更の背景
<!-- ここに変更が必要となった背景を記載してください -->

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
