### PR TITLE
PC時チャットを右に固定（aboutページのみ）

### DIFF
--- a/frontend/src/components/chat/ChatRightBar.tsx
+++ b/frontend/src/components/chat/ChatRightBar.tsx
@@ -1,0 +1,98 @@
+import { Loader2, Send } from "lucide-react";
+import type React from "react";
+import { useState } from "react";
+import { Button } from "../ui/button";
+import { useChat } from "./ChatProvider";
+import ExtendedChatHistory from "./ExtendedChatHistory";
+
+interface ChatSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSendMessage?: (message: string) => void;
+}
+
+export const ChatRightBar: React.FC<ChatSheetProps> = ({ onSendMessage }) => {
+  const { messages, addMessage } = useChat();
+  const [inputValue, setInputValue] = useState("");
+  const [isSending, setIsSending] = useState(false);
+
+  const handleSendMessage = () => {
+    if (inputValue.trim() && !isSending) {
+      setIsSending(true);
+
+      const message = inputValue;
+      setInputValue("");
+
+      if (onSendMessage) {
+        try {
+          onSendMessage(message);
+          setTimeout(() => {
+            setIsSending(false);
+          }, 1000);
+        } catch (error) {
+          console.error("Error sending message:", error);
+          setIsSending(false);
+        }
+      } else {
+        addMessage(message, "user");
+        setTimeout(() => {
+          setIsSending(false);
+        }, 1000);
+      }
+    }
+  };
+
+  const handleKeyDown = (
+    e: React.KeyboardEvent & {
+      isComposing?: boolean;
+      nativeEvent: { isComposing?: boolean };
+    }
+  ) => {
+    if (
+      e.key === "Enter" &&
+      !e.shiftKey &&
+      !isSending &&
+      !e.isComposing &&
+      !e.nativeEvent.isComposing
+    ) {
+      e.preventDefault();
+      handleSendMessage();
+    }
+  };
+
+  return (
+    <div className="fixed right-0 top-16 bottom-0 w-[400px] shadow-md shadow-gray-400 bg-white overflow-y-auto">
+      <div className="flex-grow overflow-auto h-[calc(100%-120px)]">
+        <ExtendedChatHistory messages={messages} />
+      </div>
+      <div className="p-4 border-t">
+        <div className="bg-accentGradient rounded-full p-1">
+          <div className="flex items-center bg-white rounded-full p-1">
+            <input
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="気になること・思ったことを伝える"
+              className="flex-grow px-5 py-3 bg-transparent border-none focus:outline-none text-base"
+              disabled={isSending}
+            />
+            <Button
+              onClick={handleSendMessage}
+              variant="ghost"
+              size="icon"
+              className="rounded-full h-10 w-10 mr-1 flex items-center justify-center"
+              disabled={!inputValue.trim() || isSending}
+            >
+              {isSending ? (
+                <Loader2 className="h-5 w-5 animate-spin" />
+              ) : (
+                <Send className="h-5 w-5" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/chat/FloatingChat.tsx
+++ b/frontend/src/components/chat/FloatingChat.tsx
@@ -1,9 +1,9 @@
-import { forwardRef, useImperativeHandle, useState } from "react";
+import { forwardRef, useImperativeHandle, useState, useEffect } from "react";
 import { type MessageType } from "../../types";
 import { ChatProvider, useChat } from "./ChatProvider";
 import { ChatSheet } from "./ChatSheet";
 import { FloatingChatButton } from "./FloatingChatButton";
-
+import { ChatRightBar } from "./ChatRightbar";
 interface FloatingChatProps {
   onSendMessage?: (message: string) => void;
   onClose?: () => void;
@@ -44,7 +44,33 @@ const FloatingChatInner = forwardRef<FloatingChatRef, FloatingChatProps>(
     const handleSendMessage = (message: string) => {
       onSendMessage?.(message);
     };
+    const [isXl, setIsXl] = useState(false);
+    useEffect(() => {
+      const mediaQueryList = window.matchMedia("(min-width: 1280px)");
 
+      const listener = (event) => {
+        if (event.matches) {
+          setIsXl(true);
+        } else {
+          setIsXl(false);
+        }
+      };
+
+      // リスナーを追加
+      mediaQueryList.addEventListener("change", listener);
+
+      // 初期状態を設定
+      if (mediaQueryList.matches) {
+        setIsXl(true);
+      } else {
+        setIsXl(false);
+      }
+
+      // クリーンアップ関数
+      return () => {
+        mediaQueryList.removeEventListener("change", listener);
+      };
+    }, []); // 空の依存配列で一度だけ実行
     useImperativeHandle(ref, () => ({
       addMessage: (content: string, type: MessageType) => {
         addMessage(content, type);
@@ -59,19 +85,28 @@ const FloatingChatInner = forwardRef<FloatingChatRef, FloatingChatProps>(
       endStreamingMessage,
       clearMessages,
     }));
-
-    return (
-      <>
-        {!isOpen && (
-          <FloatingChatButton onClick={handleOpen} hasUnread={hasUnread} />
-        )}
-        <ChatSheet
+    if (isXl === true) {
+      return (
+        <ChatRightBar
           isOpen={isOpen}
           onClose={handleClose}
           onSendMessage={handleSendMessage}
         />
-      </>
-    );
+      );
+    } else {
+      return (
+        <div>
+          {!isOpen && (
+            <FloatingChatButton onClick={handleOpen} hasUnread={hasUnread} />
+          )}
+          <ChatSheet
+            isOpen={isOpen}
+            onClose={handleClose}
+            onSendMessage={handleSendMessage}
+          />
+        </div>
+      );
+    }
   }
 );
 

--- a/frontend/src/components/layout/PageLayout.tsx
+++ b/frontend/src/components/layout/PageLayout.tsx
@@ -2,20 +2,35 @@ import type { ReactNode } from "react";
 import Footer from "./Footer";
 import Header from "./Header";
 import Sidebar from "./Sidebar";
+import { useLocation } from "react-router-dom";
 
 interface PageLayoutProps {
   children: ReactNode;
 }
 
 const PageLayout = ({ children }: PageLayoutProps) => {
-  return (
-    <div className="min-h-screen flex flex-col pt-14">
-      <Header />
-      <Sidebar />
-      <main className="flex-grow xl:ml-[260px] px-4 xl:px-8">{children}</main>
-      <Footer />
-    </div>
-  );
+  const nowPagePath = location.pathname;
+  if (nowPagePath === "/about") {
+    return (
+      <div className="min-h-screen flex flex-col pt-14">
+        <Header />
+        <Sidebar />
+        <main className="flex-grow xl:ml-[260px] px-4 xl:pl-8 xl:mr-[400px]">
+          {children}
+        </main>
+        <Footer />
+      </div>
+    );
+  } else {
+    return (
+      <div className="min-h-screen flex flex-col pt-14">
+        <Header />
+        <Sidebar />
+        <main className="flex-grow xl:ml-[260px] px-4 xl:px-8">{children}</main>
+        <Footer />
+      </div>
+    );
+  }
 };
 
 export default PageLayout;

--- a/frontend/src/components/layout/PageLayout.tsx
+++ b/frontend/src/components/layout/PageLayout.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from "react";
 import Footer from "./Footer";
 import Header from "./Header";
 import Sidebar from "./Sidebar";
-import { useLocation } from "react-router-dom";
 
 interface PageLayoutProps {
   children: ReactNode;


### PR DESCRIPTION
プルリクの仕方間違ってたすみません。
その際はご教示いただきたいです。

# 変更の概要
aboutページのみですが、PC表示時、チャットを右に固定にしました。

# スクリーンショット
![image](https://github.com/user-attachments/assets/21af1a19-d436-4dfa-a687-a0c442cca486)

# 変更の背景
PC時のUXの向上のため。

# 関連Issue
#252 

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
