### PR TITLE
[UI] チャット入力欄へのfocusの改善

### DIFF
--- a/frontend/src/components/chat/ChatSheet.tsx
+++ b/frontend/src/components/chat/ChatSheet.tsx
@@ -1,6 +1,6 @@
 import { Loader2, Send } from "lucide-react";
 import type React from "react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useDraggable } from "../../hooks/useDraggable";
 import { Button } from "../ui/button";
 import {
@@ -30,6 +30,13 @@ export const ChatSheet: React.FC<ChatSheetProps> = ({
     maxHeight: window.innerHeight * 0.8,
     initialHeight: 500,
   });
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!isSending && isOpen) {
+      inputRef.current.focus();
+    }
+  }, [isSending]);
 
   const handleSendMessage = () => {
     if (inputValue.trim() && !isSending) {
@@ -80,6 +87,10 @@ export const ChatSheet: React.FC<ChatSheetProps> = ({
       <ChatSheetContent
         className="p-0 h-auto rounded-t-xl overflow-hidden"
         style={{ height: `${height}px` }}
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          inputRef.current.focus();
+        }}
       >
         <ChatHeader
           onDragStart={handleDragStart}
@@ -99,6 +110,7 @@ export const ChatSheet: React.FC<ChatSheetProps> = ({
                 placeholder="気になること・思ったことを伝える"
                 className="flex-grow px-5 py-3 bg-transparent border-none focus:outline-none text-base"
                 disabled={isSending}
+                ref={inputRef}
               />
               <Button
                 onClick={handleSendMessage}


### PR DESCRIPTION
# 変更の概要
入力欄をクリックした時にフォーカスが一回で入力欄に移るようにしました。
またチャットを送信した時にもフォーカスが入力欄に留まるようにしました。

## 補足
チャットの送信後は処理の完了を待つため、再び入力欄にフォーカスが当たるまで一瞬時間がかかります。

# スクリーンショット
<img width="1021" alt="スクリーンショット 2025-05-12 0 38 02" src="https://github.com/user-attachments/assets/dbce3ea1-d71b-4c5c-ac32-e71a6f2b286f" />

# 関連Issue
fix #201

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
