### PR TITLE
Update: リンクワーカーが意見を紐づけるときにテーマIDを参照するように変更

### DIFF
--- a/idea-discussion/backend/workers/linkingWorker.js
+++ b/idea-discussion/backend/workers/linkingWorker.js
@@ -52,7 +52,9 @@ async function linkItemToQuestions(itemId, itemType) {
     // Only fetch questions from the same theme
     const questions = await SharpQuestion.find({ themeId: itemThemeId });
     if (questions.length === 0) {
-      console.log(`[LinkingWorker] No sharp questions found in theme ${itemThemeId} to link against.`);
+      console.log(
+        `[LinkingWorker] No sharp questions found in theme ${itemThemeId} to link against.`
+      );
       return;
     }
 


### PR DESCRIPTION
# 変更の概要
- リンクワーカーが意見を紐づけるとき、これまでは他テーマのものも紐づいてしまっていた
- テーマIDを参照するようにして

# スクリーンショット
* 問いがうまく生成できることを確認した
* 他テーマの意見が紐づいていないことを目視で確認した

<img width="1335" alt="image" src="https://github.com/user-attachments/assets/10761c8f-3f3b-4a01-9d1a-13e09f2f1659" />


# 変更の背景
バグ報告

# 関連Issue
https://github.com/digitaldemocracy2030/idobata/issues/265

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
