### PR TITLE
Update: 見せたくないディレクトリをignoreする設定を追加

### DIFF
--- a/policy-edit/frontend/src/components/DirectoryView.tsx
+++ b/policy-edit/frontend/src/components/DirectoryView.tsx
@@ -2,6 +2,7 @@
 import type React from "react";
 import { FaFileAlt, FaFolder } from "react-icons/fa"; // Folder and File icons
 import { Link } from "react-router-dom";
+import { ignoredDirectories } from "../lib/config"; // Import ignored directories config
 
 // Define the expected structure of items in the directory data array
 // This should align with the GitHub API response for directory contents
@@ -32,7 +33,25 @@ const DirectoryView: React.FC<DirectoryViewProps> = ({ data }) => {
     return name.endsWith(".md") ? name.slice(0, -3) : name;
   };
 
-  const filteredData = data.filter((item) => !item.name.startsWith("."));
+  // Filter out hidden files and ignored directories
+  const filteredData = data.filter((item) => {
+    // Skip hidden files/directories (starting with .)
+    if (item.name.startsWith(".")) return false;
+
+    // Skip directories that are in the ignoredDirectories list
+    if (item.type === "dir" && ignoredDirectories.includes(item.name)) return false;
+
+    // Skip files/directories that are inside ignored directories
+    // Check if the path contains any of the ignored directory names
+    for (const ignoredDir of ignoredDirectories) {
+      // Match exact directory or subdirectory pattern
+      // e.g., "images" or "path/images" or "path/images/subdir"
+      const pathPattern = new RegExp(`(^|/)${ignoredDir}(/|$)`);
+      if (pathPattern.test(item.path)) return false;
+    }
+
+    return true;
+  });
 
   return (
     <div className="border rounded overflow-hidden">

--- a/policy-edit/frontend/src/lib/config.ts
+++ b/policy-edit/frontend/src/lib/config.ts
@@ -1,0 +1,12 @@
+/**
+ * Configuration settings for the policy-edit frontend
+ */
+
+/**
+ * List of directory names to ignore when displaying GitHub repository contents
+ * These directories and their subdirectories will be hidden from the UI
+ */
+export const ignoredDirectories: string[] = [
+  // Add directory names to ignore here
+  "tools"
+];


### PR DESCRIPTION
# 変更の概要
* policyリポジトリにtoolsという便利スクリプトを追加したらUIに表示されるようになってしまった
* ignoreDirectoriesというところに名前を書いたらDirectoryViewに出ないようになる機能を追加した

# スクリーンショット
なし

# 変更の背景
* policyリポジトリにtoolsという便利スクリプトを追加したらUIに表示されるようになってしまった

# 関連Issue
なし

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
