### PR TITLE
update policy-edit front: Do not show LICENSE file

### DIFF
--- a/policy-edit/frontend/src/components/DirectoryView.tsx
+++ b/policy-edit/frontend/src/components/DirectoryView.tsx
@@ -32,7 +32,7 @@ const DirectoryView: React.FC<DirectoryViewProps> = ({ data }) => {
     return name.endsWith(".md") ? name.slice(0, -3) : name;
   };
 
-  const filteredData = data.filter((item) => !item.name.startsWith("."));
+  const filteredData = data.filter((item) => !item.name.startsWith(".") && item.name.includes("."));
 
   return (
     <div className="border rounded overflow-hidden">

--- a/policy-edit/frontend/src/components/DirectoryView.tsx
+++ b/policy-edit/frontend/src/components/DirectoryView.tsx
@@ -32,8 +32,13 @@ const DirectoryView: React.FC<DirectoryViewProps> = ({ data }) => {
     return name.endsWith(".md") ? name.slice(0, -3) : name;
   };
 
-  const filteredData = data.filter((item) => !item.name.startsWith(".") && 
-    !["license", "license.md", "license.txt", "license.rst"].includes(item.name.toLowerCase()));
+  const filteredData = data.filter(
+    (item) =>
+      !item.name.startsWith(".") &&
+      !["license", "license.md", "license.txt", "license.rst"].includes(
+        item.name.toLowerCase()
+      )
+  );
 
   return (
     <div className="border rounded overflow-hidden">

--- a/policy-edit/frontend/src/components/DirectoryView.tsx
+++ b/policy-edit/frontend/src/components/DirectoryView.tsx
@@ -32,7 +32,8 @@ const DirectoryView: React.FC<DirectoryViewProps> = ({ data }) => {
     return name.endsWith(".md") ? name.slice(0, -3) : name;
   };
 
-  const filteredData = data.filter((item) => !item.name.startsWith(".") && item.name.includes("."));
+  const filteredData = data.filter((item) => !item.name.startsWith(".") && 
+    !["license", "license.md", "license.txt", "license.rst"].includes(item.name.toLowerCase()));
 
   return (
     <div className="border rounded overflow-hidden">


### PR DESCRIPTION
# 変更の概要
拡張子のないファイルを見せない。

# スクリーンショット
（すみません、ローカルで構築できていません。どなたかご確認いただけないでしょうか。）

# 変更の背景
チームみらいのいどばた政策立案で「LICENSE」ファイルが一覧に表示されてしまっている（プレビューはできない）

# 関連Issue
なし

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。
- [x] CLAの内容を読み、同意しました
