### PR TITLE
Feature/disable delete option

### DIFF
--- a/admin/src/components/theme/ThemeTable.tsx
+++ b/admin/src/components/theme/ThemeTable.tsx
@@ -15,6 +15,10 @@ const ThemeTable: FC<ThemeTableProps> = ({ themes, onDelete }) => {
     return new Date(dateString).toLocaleString("ja-JP");
   };
 
+  // 環境変数からテーマ削除機能の有効/無効を取得
+  // VITE_で始まる環境変数はクライアントサイドで利用可能
+  const allowDeleteTheme = import.meta.env.VITE_ALLOW_DELETE_THEME === "true";
+
   return (
     <div className="overflow-x-auto">
       <table className="min-w-full bg-background border border-border">
@@ -60,12 +64,14 @@ const ThemeTable: FC<ThemeTableProps> = ({ themes, onDelete }) => {
                   <Link to={`/themes/${theme._id}`}>
                     <Button variant="secondary">編集</Button>
                   </Link>
-                  <Button
-                    variant="destructive"
-                    onClick={() => onDelete(theme._id)}
-                  >
-                    削除
-                  </Button>
+                  {allowDeleteTheme && (
+                    <Button
+                      variant="destructive"
+                      onClick={() => onDelete(theme._id)}
+                    >
+                      削除
+                    </Button>
+                  )}
                 </td>
               </tr>
             ))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - IDEA_CORS_ORIGIN=${IDEA_CORS_ORIGIN}
       - JWT_SECRET=${JWT_SECRET} # Pass JWT secret from .env
       - JWT_EXPIRES_IN=${JWT_EXPIRES_IN:-1d} # Pass expiration, default to 1 day
-      - ALLOW_DELETE_THEME=${ALLOW_DELETE_THEME:-false} # Pass theme deletion control, default to false
+      - ALLOW_DELETE_THEME=${ALLOW_DELETE_THEME} # Pass theme deletion control
     # Use the CMD defined in the Dockerfile's development stage
     command: npm run dev
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - IDEA_CORS_ORIGIN=${IDEA_CORS_ORIGIN}
       - JWT_SECRET=${JWT_SECRET} # Pass JWT secret from .env
       - JWT_EXPIRES_IN=${JWT_EXPIRES_IN:-1d} # Pass expiration, default to 1 day
+      - ALLOW_DELETE_THEME=${ALLOW_DELETE_THEME:-false} # Pass theme deletion control, default to false
     # Use the CMD defined in the Dockerfile's development stage
     command: npm run dev
 
@@ -136,6 +137,7 @@ services:
       - NODE_ENV=development
       - VITE_API_BASE_URL=${ADMIN_API_BASE_URL} # idea-discussionバックエンドを指す
       - VITE_ADMIN_FRONTEND_ALLOWED_HOSTS=${VITE_ADMIN_FRONTEND_ALLOWED_HOSTS}
+      - VITE_ALLOW_DELETE_THEME=${ALLOW_DELETE_THEME}
 
   # --- Python Embedding Service ---
   python-service:

--- a/idea-discussion/backend/controllers/themeController.js
+++ b/idea-discussion/backend/controllers/themeController.js
@@ -150,6 +150,17 @@ export const updateTheme = async (req, res) => {
 export const deleteTheme = async (req, res) => {
   const { themeId } = req.params;
 
+  // 環境変数からテーマ削除機能の有効/無効を取得
+  // 設定がない場合やfalseの場合は、テーマの削除機能は無効
+  const allowDeleteTheme = process.env.ALLOW_DELETE_THEME === "true";
+
+  // テーマ削除機能が無効の場合は400エラーを返す
+  if (!allowDeleteTheme) {
+    return res.status(400).json({
+      message: "Theme deletion is disabled. Set ALLOW_DELETE_THEME=true to enable this feature."
+    });
+  }
+
   if (!mongoose.Types.ObjectId.isValid(themeId)) {
     return res.status(400).json({ message: "Invalid theme ID format" });
   }

--- a/idea-discussion/backend/controllers/themeController.js
+++ b/idea-discussion/backend/controllers/themeController.js
@@ -157,7 +157,8 @@ export const deleteTheme = async (req, res) => {
   // テーマ削除機能が無効の場合は400エラーを返す
   if (!allowDeleteTheme) {
     return res.status(400).json({
-      message: "Theme deletion is disabled. Set ALLOW_DELETE_THEME=true to enable this feature."
+      message:
+        "Theme deletion is disabled. Set ALLOW_DELETE_THEME=true to enable this feature.",
     });
   }
 


### PR DESCRIPTION
# 変更の概要
- チームみらいの運用で、外部のボランティアへ公開するためにテーマ削除を不可能にしたいという要望があった
- そこで環境変数で設定できるようにした（デフォルトはこれまでと変えず削除OK）

# スクリーンショット
![image](https://github.com/user-attachments/assets/fa3f18b6-c5ce-44c4-a77e-8a4878f3bbd4)
削除が消えた状態

# 変更の背景
- チームみらいで発生したニーズ

# 関連Issue
なし

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
