### PR TITLE
openrouter の API Call で tools の description を渡すようにする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2202,14 +2202,14 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.10.2.tgz",
-      "integrity": "sha512-rb6AMp2DR4SN+kc6L1ta2NCpApyA9WYNx3CrTSZvGxq9wH71bRur+zRqPfg0vQ9mjywR7qZdX2RGHOPq3ss+tA==",
-      "license": "MIT",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.12.1.tgz",
+      "integrity": "sha512-KG1CZhZfWg+u8pxeM/mByJDScJSrjjxLc8fwQqbsS8xCjBmQfMNEBTotYdNanKekepnfRI85GtgQlctLFpcYPw==",
       "dependencies": {
+        "ajv": "^6.12.6",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
-        "cross-spawn": "^7.0.3",
+        "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "express": "^5.0.1",
         "express-rate-limit": "^7.5.0",
@@ -4318,6 +4318,21 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -6323,6 +6338,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -6350,6 +6370,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-redact": {
       "version": "3.5.0",
@@ -7605,6 +7630,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -12555,6 +12585,14 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/url-parse": {

--- a/policy-edit/mcp/src/server.ts
+++ b/policy-edit/mcp/src/server.ts
@@ -15,8 +15,6 @@ const server = new McpServer({
 // upsert_file_and_commit ツールを登録
 const upsertFileAnnotations = {
   title: "Update File and Commit",
-  description:
-    "Creates or updates a specified Markdown file in a branch and commits the changes. Automatically creates the branch and a draft pull request if they don't exist.",
   readOnlyHint: false,
   destructiveHint: false, // 上書きはするが破壊的ではない
   idempotentHint: false, // 同じ内容でもコミットは増える
@@ -25,16 +23,15 @@ const upsertFileAnnotations = {
 
 server.tool(
   "upsert_file_and_commit",
+  "Creates or updates a specified Markdown file in a branch and commits the changes. Automatically creates the branch and a draft pull request if they don't exist.",
   upsertFileSchema.shape, // Pass the Zod schema shape
+  upsertFileAnnotations,
   handleUpsertFile // Pass the handler function
-  // Remove annotations argument for now
 );
 
 // update_pr_description ツールを登録
 const updatePrAnnotations = {
   title: "Update Pull Request Title and Description",
-  description:
-    "Updates the title and/or description (body) of the open pull request associated with the specified branch.",
   readOnlyHint: false,
   destructiveHint: false,
   idempotentHint: true, // 同じ説明文なら結果は同じ
@@ -43,9 +40,10 @@ const updatePrAnnotations = {
 
 server.tool(
   "update_pr",
+  "Updates the title and/or description (body) of the open pull request associated with the specified branch.",
   updatePrSchema.shape, // Pass the Zod schema shape
+  updatePrAnnotations,
   handleUpdatePr // Pass the handler function
-  // Remove annotations argument for now
 );
 
 export default server;


### PR DESCRIPTION
# 変更の概要
<!-- ここに変更の概要を記載してください -->
openrouter の API Call で tools の description を渡すようにする。

# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->

# 変更の背景
<!-- ここに変更が必要となった背景を記載してください -->
現在は openrouter の API Call において tools parameter で渡す内容のうち description が空になっています。
これでも pr の作成/更新はできているので問題がないとは思われますが、LLM に渡す情報は多い方が今後 model を変更した際など有用であると考えます。

MCP TypeScript SDK (1.21.1)において、以下の interface を用いてオブジェクトを生成しておくことで、openrouter の API について description が渡せることが確認できました。
https://github.com/modelcontextprotocol/typescript-sdk/blob/590d4841373fc4eb86ecc9079834353a98cb84a3/src/server/mcp.ts#L724
```
  tool<Args extends ZodRawShape>(
    name: string,
    description: string,
    paramsSchema: Args,
    annotations: ToolAnnotations,
    cb: ToolCallback<Args>,
  ): RegisteredTool;
```

また ToolAnnotations の型定義において description は定義されておりませんので、upsertFileAnnotations/updatePrAnnotations  からは設定値を省きました。
https://github.com/modelcontextprotocol/typescript-sdk/blob/590d4841373fc4eb86ecc9079834353a98cb84a3/src/types.ts#L770


# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->
https://github.com/digitaldemocracy2030/idobata/issues/375

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [X] CLAの内容を読み、同意しました
