### PR TITLE
チャットでマークダウンを表示できるように変更

### DIFF
--- a/frontend/src/components/chat/common/ExtendedChatHistory.tsx
+++ b/frontend/src/components/chat/common/ExtendedChatHistory.tsx
@@ -7,6 +7,8 @@ import {
   UserMessage,
 } from "../../../types";
 import { StreamingText } from "./StreamingText";
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 interface ExtendedChatHistoryProps {
   messages: Message[];
@@ -56,11 +58,13 @@ function ExtendedChatHistory({ messages }: ExtendedChatHistoryProps) {
               })}
             >
               <div className="text-sm whitespace-pre-wrap">
-                {msg.isStreaming ? (
-                  <StreamingText content={msg.content} />
-                ) : (
-                  msg.content
-                )}
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {msg.isStreaming ? (
+                    <StreamingText content={msg.content} />
+                  ) : (
+                      msg.content
+                    )}
+                </ReactMarkdown>
               </div>
             </div>
             {/* タイムスタンプは表示しない */}


### PR DESCRIPTION
# 変更の概要
ReactMarkdownを使用し、チャットの内容にマークダウンが含まれていても表示できるようにしました。
コメントで表について特に言及されていたため、動作確認は表でしか行っておりません。

# スクリーンショット
変更前
![image](https://github.com/user-attachments/assets/64235fec-7151-446f-bde7-d6c9aa84243b)

変更後
![image](https://github.com/user-attachments/assets/dfec5fcf-8d29-4fc1-ab68-05ee34d9dab0)

# 変更の背景
Issue対応

# 関連Issue
#203 

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
