### PR TITLE
シードデータ投入のパスを修正

### DIFF
--- a/idea-discussion/tmp/import_comments.py
+++ b/idea-discussion/tmp/import_comments.py
@@ -3,9 +3,12 @@ import json
 import html
 import requests
 
-# ファイル名
+# 実際のファイル名に変更してください
 csv_file = "driving.csv"
-endpoint = "http://localhost:3000/api/import/generic"
+# 実際のテーマIDに変更してください
+theme_id = "xxxxxxxxxxx"
+# 実際のエンドポイントに変更してください
+endpoint = "http://localhost:3000/api/themes/{themeId}/import/generic"
 
 with open(csv_file, newline='', encoding='utf-8') as f:
     reader = csv.DictReader(f)


### PR DESCRIPTION
# 変更の概要
<!-- ここに変更の概要を記載してください -->
シードデータを投入するendpointに`themeId` を追加してシードデータを投入できるようにした。
[backendのコード](https://github.com/digitaldemocracy2030/idobata/blob/main/idea-discussion/backend/controllers/importController.js)を確認すると、`themeId` をpathに追加する必要があったため。


# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->

# 変更の背景
https://github.com/digitaldemocracy2030/idobata/tree/main/idea-discussion#シードデータの投入方法 を参考に
シードデータを投入しようとしたができなかったため。
<!-- ここに変更が必要となった背景を記載してください -->

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->
https://github.com/digitaldemocracy2030/idobata/issues/408
# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
