### PR TITLE
api側のCORSエラー判定を少し緩くしたい。

### DIFF
--- a/idea-discussion/backend/server.js
+++ b/idea-discussion/backend/server.js
@@ -33,7 +33,7 @@ const httpServer = createServer(app);
 const io = new Server(httpServer, {
   cors: {
     origin: process.env.IDEA_CORS_ORIGIN
-      ? process.env.IDEA_CORS_ORIGIN.split(",")
+      ? process.env.IDEA_CORS_ORIGIN.split(",").map((url) => url.trim())
       : ["http://localhost:5173", "http://localhost:5175"],
     methods: ["GET", "POST"],
     credentials: true,


### PR DESCRIPTION
# 変更の概要
<!-- ここに変更の概要を記載してください -->
環境変数`IDEA_CORS_ORIGIN` には、ユーザー用frontendとadmin用frontend(= 管理画面)の2つのURLが設定されるはずで、カンマ区切りの前後にスペースがあれば、

たとえば
`IDEA_CORS_ORIGIN=http://localhost:5173,   http://localhost:5175` 
のように、カンマの後ろにspaceが入ると、後ろのURLが文頭にspaceが入った`  http://localhost:5175`となり、正しいURL`http://localhost:5175`と認識されず、CORSエラーになってAPIを叩けない。 
意図せずspaceが入る時があるので、その場合はtrimでspaceを削除し、正しいURLとして認識させたい。

# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->

# 変更の背景
<!-- ここに変更が必要となった背景を記載してください -->

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->
https://github.com/digitaldemocracy2030/idobata/issues/412
# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
