### PR TITLE
Update: breadcrumb

### DIFF
--- a/frontend/src/components/common/BreadcrumbView.tsx
+++ b/frontend/src/components/common/BreadcrumbView.tsx
@@ -1,3 +1,4 @@
+import { Home } from "lucide-react";
 import { Link } from "../../contexts/MockContext";
 
 interface BreadcrumbItem {
@@ -7,19 +8,35 @@ interface BreadcrumbItem {
 
 interface BreadcrumbViewProps {
   items: BreadcrumbItem[];
+  homeHref?: string;
 }
 
-export function BreadcrumbView({ items }: BreadcrumbViewProps) {
+export function BreadcrumbView({ items, homeHref = "/" }: BreadcrumbViewProps) {
   return (
-    <nav className="text-sm text-muted-foreground mb-2" aria-label="Breadcrumb">
-      {items.map((item, index) => (
-        <span key={`${item.label}-${index}`}>
-          <Link to={item.href} className="underline">
-            {item.label}
-          </Link>
-          {index < items.length - 1 && " ＞ "}
-        </span>
-      ))}
+    <nav className="text-left py-2" aria-label="Breadcrumb">
+      <div className="inline text-[10px] leading-[1.5] tracking-[0.03em]">
+        {/* ホームアイコン + "トップ" */}
+        <Link
+          to={homeHref}
+          className="inline-flex items-baseline gap-1 text-secondary-500 hover:text-secondary-600 transition-colors no-underline"
+        >
+          <Home size={12} strokeWidth={1} className="inline-block translate-y-0.5" />
+          <span>トップ</span>
+        </Link>
+
+        {/* パンくずリスト */}
+        {items.map((item, index) => (
+          <span key={`${item.label}-${index}`}>
+            <span className="text-secondary-500 mx-1"> {'>'} </span>
+            <Link
+              to={item.href}
+              className="text-secondary-500 no-underline hover:text-secondary-600 transition-colors"
+            >
+              {item.label}
+            </Link>
+          </span>
+        ))}
+      </div>
     </nav>
   );
 }

--- a/frontend/src/components/common/BreadcrumbView.tsx
+++ b/frontend/src/components/common/BreadcrumbView.tsx
@@ -20,14 +20,18 @@ export function BreadcrumbView({ items, homeHref = "/" }: BreadcrumbViewProps) {
           to={homeHref}
           className="inline-flex items-baseline gap-1 text-secondary-500 hover:text-secondary-600 transition-colors no-underline"
         >
-          <Home size={12} strokeWidth={1} className="inline-block translate-y-0.5" />
+          <Home
+            size={12}
+            strokeWidth={1}
+            className="inline-block translate-y-0.5"
+          />
           <span>トップ</span>
         </Link>
 
         {/* パンくずリスト */}
         {items.map((item, index) => (
           <span key={`${item.label}-${index}`}>
-            <span className="text-secondary-500 mx-1"> {'>'} </span>
+            <span className="text-secondary-500 mx-1"> {">"} </span>
             <Link
               to={item.href}
               className="text-secondary-500 no-underline hover:text-secondary-600 transition-colors"

--- a/frontend/src/components/theme/ThemeDetailTemplate.tsx
+++ b/frontend/src/components/theme/ThemeDetailTemplate.tsx
@@ -116,7 +116,6 @@ const ThemeDetailTemplate = forwardRef<
     };
 
     const breadcrumbItems = [
-      { label: "TOP", href: "/" },
       { label: "テーマ一覧", href: "/themes" },
       { label: theme.title, href: `/themes/${theme._id}` },
     ];

--- a/frontend/src/components/top/TopPageTemplate.tsx
+++ b/frontend/src/components/top/TopPageTemplate.tsx
@@ -51,7 +51,7 @@ const TopPageTemplate = ({
   return (
     <div className="min-h-screen bg-white">
       <div className="container mx-auto px-4 pt-2">
-        <BreadcrumbView items={[{ label: "トップページ", href: "/top" }]} />
+        <BreadcrumbView items={[]} />
       </div>
 
       <HeroSection latestQuestions={latestQuestions} />

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -4,7 +4,6 @@ import { useSiteConfig } from "../contexts/SiteConfigContext";
 
 const About = () => {
   const breadcrumbItems = [
-    { label: "TOP", href: "/" },
     { label: "このサイトについて", href: "/about" },
   ];
 

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -3,9 +3,7 @@ import MarkdownRenderer from "../components/common/MarkdownRenderer";
 import { useSiteConfig } from "../contexts/SiteConfigContext";
 
 const About = () => {
-  const breadcrumbItems = [
-    { label: "このサイトについて", href: "/about" },
-  ];
+  const breadcrumbItems = [{ label: "このサイトについて", href: "/about" }];
 
   const { siteConfig, loading } = useSiteConfig();
 

--- a/frontend/src/pages/CommentsPage.tsx
+++ b/frontend/src/pages/CommentsPage.tsx
@@ -105,7 +105,6 @@ const CommentsPage = () => {
       ? mockQuestionData
       : questionDetail;
     const breadcrumbItems = [
-      { label: "TOP", href: "/" },
       { label: "テーマ一覧", href: "/themes" },
       {
         label: "テーマ詳細",

--- a/frontend/src/pages/QuestionDetail.tsx
+++ b/frontend/src/pages/QuestionDetail.tsx
@@ -285,7 +285,6 @@ const QuestionDetail = () => {
         });
 
     const breadcrumbItems = [
-      { label: "TOP", href: "/" },
       { label: "テーマ一覧", href: "/themes" },
       { label: themeData.title, href: `/themes/${themeId}` },
       {

--- a/frontend/src/pages/Themes.tsx
+++ b/frontend/src/pages/Themes.tsx
@@ -7,7 +7,6 @@ import { useThemes } from "../hooks/useThemes";
 
 const Themes = () => {
   const breadcrumbItems = [
-    { label: "TOP", href: "/" },
     { label: "テーマ一覧", href: "/themes" },
   ];
 

--- a/frontend/src/pages/Themes.tsx
+++ b/frontend/src/pages/Themes.tsx
@@ -6,9 +6,7 @@ import ThemeCard from "../components/home/ThemeCard";
 import { useThemes } from "../hooks/useThemes";
 
 const Themes = () => {
-  const breadcrumbItems = [
-    { label: "テーマ一覧", href: "/themes" },
-  ];
+  const breadcrumbItems = [{ label: "テーマ一覧", href: "/themes" }];
 
   const chatRef = useRef<FloatingChatRef>(null);
   const { themes, isLoading, error } = useThemes();


### PR DESCRIPTION
# 変更の概要
パンくずのデザインを修正

# スクリーンショット
<img width="986" height="755" alt="image" src="https://github.com/user-attachments/assets/2517b902-50b7-4d44-8e3c-7bc249d92c7a" />


# 変更の背景
ウタコデザイン

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
