### PR TITLE
chore:  idea-discussion 内の不要な devDependencies を削除

### DIFF
--- a/idea-discussion/backend/package.json
+++ b/idea-discussion/backend/package.json
@@ -34,11 +34,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
-    "@types/bcryptjs": "^2.4.6",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.5",
-    "@types/mongoose": "^5.11.97",
     "@types/node": "^20.11.5",
     "nodemon": "^3.1.9",
     "socket.io-client": "^4.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -302,11 +302,9 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@types/bcryptjs": "^2.4.6",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.5",
-        "@types/mongoose": "^5.11.97",
         "@types/node": "^20.11.5",
         "nodemon": "^3.1.9",
         "socket.io-client": "^4.8.1",
@@ -3875,13 +3873,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/bcryptjs": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
-      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -4017,17 +4008,6 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/mongoose": {
-      "version": "5.11.97",
-      "resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.11.97.tgz",
-      "integrity": "sha512-cqwOVYT3qXyLiGw7ueU2kX9noE8DPGRY6z8eUxudhXY8NZ7DMKYAxyZkLSevGfhCX3dO/AoX5/SO9lAzfjon0Q==",
-      "deprecated": "Mongoose publishes its own types, so you do not need to install this package.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mongoose": "*"
-      }
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",


### PR DESCRIPTION
# 変更の概要
idea-discussion 内の不要な devDependencies を削除
- 元のパッケージ自体に型が含まれるようになったため不要
  - <https://www.npmjs.com/package/@types/mongoose> 
  - <https://www.npmjs.com/package/@types/bcryptjs>

# スクリーンショット
なし

# 変更の背景
npm install 時に deprecated のワーニングが出ていたため対応

# 関連Issue
なし

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
