### PR TITLE
refactor: 使用していない crypto を削除

### DIFF
--- a/idea-discussion/backend/models/AdminUser.js
+++ b/idea-discussion/backend/models/AdminUser.js
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import bcrypt from "bcryptjs";
 import mongoose from "mongoose";
 

--- a/idea-discussion/backend/package.json
+++ b/idea-discussion/backend/package.json
@@ -21,7 +21,6 @@
     "axios": "^1.9.0",
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
-    "crypto": "^1.0.1",
     "dotenv": "^16.4.7",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -289,7 +289,6 @@
         "axios": "^1.9.0",
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
-        "crypto": "^1.0.1",
         "dotenv": "^16.4.7",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
@@ -5457,13 +5456,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.",
-      "license": "ISC"
     },
     "node_modules/css-select": {
       "version": "4.3.0",


### PR DESCRIPTION
# 変更の概要
使用していない crypto を削除

# スクリーンショット
なし

# 変更の背景
npm i 実行時に、cryptoパッケージを使用せずに node の crypto  を使うようにワーニングが出ていた。  
確認したところ、そもそも crypto を使っていないようだったので対応。

# 関連Issue
なし

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
