### PR TITLE
userId の取り回しでバグがあったのを修正した

### DIFF
--- a/frontend/src/components/theme/ThemeDetailTemplate.tsx
+++ b/frontend/src/components/theme/ThemeDetailTemplate.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 import { apiClient } from "../../services/api/apiClient";
 import { MessageType } from "../../types";
+import { userIdManager } from "../../utils/userIdManager";
 import { FloatingChat, type FloatingChatRef } from "../chat";
 import BreadcrumbView from "../common/BreadcrumbView";
 import SectionHeading from "../common/SectionHeading";
@@ -53,9 +54,7 @@ const ThemeDetailTemplate = forwardRef<
     );
     const chatRef = useRef<FloatingChatRef>(null);
     const [threadId, setThreadId] = useState<string | null>(null);
-    const [userId, setUserId] = useState<string>(
-      localStorage.getItem("userId") || crypto.randomUUID()
-    );
+    const [userId, setUserId] = useState<string>(() => userIdManager.getUserId());
 
     useImperativeHandle(ref, () => ({
       addMessage: (content: string, type: MessageType) => {
@@ -111,7 +110,7 @@ const ThemeDetailTemplate = forwardRef<
 
       if (responseData.userId && responseData.userId !== userId) {
         setUserId(responseData.userId);
-        localStorage.setItem("userId", responseData.userId);
+        userIdManager.setUserId(responseData.userId);
       }
     };
 
@@ -122,8 +121,8 @@ const ThemeDetailTemplate = forwardRef<
     ];
 
     useEffect(() => {
-      if (!localStorage.getItem("userId")) {
-        localStorage.setItem("userId", userId);
+      if (!userIdManager.getUserId()) {
+        userIdManager.setUserId(userId);
       }
     }, [userId]);
 

--- a/frontend/src/components/theme/ThemeDetailTemplate.tsx
+++ b/frontend/src/components/theme/ThemeDetailTemplate.tsx
@@ -54,7 +54,9 @@ const ThemeDetailTemplate = forwardRef<
     );
     const chatRef = useRef<FloatingChatRef>(null);
     const [threadId, setThreadId] = useState<string | null>(null);
-    const [userId, setUserId] = useState<string>(() => userIdManager.getUserId());
+    const [userId, setUserId] = useState<string>(() =>
+      userIdManager.getUserId()
+    );
 
     useImperativeHandle(ref, () => ({
       addMessage: (content: string, type: MessageType) => {

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
-import { v4 as uuidv4 } from "uuid";
 import { apiClient } from "../services/api/apiClient";
+import { userIdManager } from "../utils/userIdManager";
 
 interface User {
   id: string;
@@ -39,12 +39,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 
   useEffect(() => {
     const initializeUser = async () => {
-      let userId = localStorage.getItem("idobataUserId");
-
-      if (!userId) {
-        userId = uuidv4();
-        localStorage.setItem("idobataUserId", userId);
-      }
+      const userId = userIdManager.getUserId();
 
       const result = await apiClient.getUserInfo(userId);
 

--- a/frontend/src/utils/userIdManager.ts
+++ b/frontend/src/utils/userIdManager.ts
@@ -5,13 +5,13 @@ const USER_ID_KEY = "idobataUserId";
 export const userIdManager = {
   getUserId(): string {
     let userId = localStorage.getItem(USER_ID_KEY);
-    
+
     // 存在しない場合は新規作成して保存
     if (!userId) {
       userId = uuidv4();
       this.setUserId(userId);
     }
-    
+
     return userId;
   },
 

--- a/frontend/src/utils/userIdManager.ts
+++ b/frontend/src/utils/userIdManager.ts
@@ -1,0 +1,21 @@
+import { v4 as uuidv4 } from "uuid";
+
+const USER_ID_KEY = "idobataUserId";
+
+export const userIdManager = {
+  getUserId(): string {
+    let userId = localStorage.getItem(USER_ID_KEY);
+    
+    // 存在しない場合は新規作成して保存
+    if (!userId) {
+      userId = uuidv4();
+      this.setUserId(userId);
+    }
+    
+    return userId;
+  },
+
+  setUserId(userId: string): void {
+    localStorage.setItem(USER_ID_KEY, userId);
+  },
+};


### PR DESCRIPTION
# 変更の概要
<!-- ここに変更の概要を記載してください -->

idobata クライアントでは localStorage に user id を入れて取り回しているが、localStorage の読み書き時のキーが userId と idobataUserId で揺れていて、おそらくページによって一人の利用者が二人のユーザーとして振る舞ってしまうバグがあった。

文字列キーで読み書きするのは今回のような書き間違いを起こしやすいので、userIdManager を作って統一的に行えるようにした。

# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->

# 変更の背景
<!-- ここに変更が必要となった背景を記載してください -->

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
