### PR TITLE
Update: ウタコデザインとの微妙なズレを修正

### DIFF
--- a/frontend/src/components/theme/ThemeCard.tsx
+++ b/frontend/src/components/theme/ThemeCard.tsx
@@ -15,7 +15,7 @@ const ThemeCard = ({
       <div className="absolute inset-0 bg-white/70" />
 
       {/* 装飾的な円 */}
-      <div className="absolute -top-[310px] left-9 h-[550px] w-[550px] rounded-full border-[100px] border-white/40" />
+      <div className="absolute -top-[310px] -right-[250px] h-[550px] w-[550px] rounded-full border-[100px] border-white/40" />
 
       <div className="relative z-10 space-y-3">
         {/* お題ラベル */}

--- a/frontend/src/pages/QuestionDetail.tsx
+++ b/frontend/src/pages/QuestionDetail.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, Lightbulb } from "lucide-react";
+import { Lightbulb, SquareChartGantt } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import { FloatingChat, type FloatingChatRef } from "../components/chat";
@@ -236,7 +236,7 @@ const QuestionDetail = () => {
               <div className="flex flex-col md:flex-row md:justify-between md:items-center gap-4 md:gap-0">
                 <div className="flex items-center gap-4">
                   <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center">
-                    <BarChart3 className="w-8 h-8 text-blue-400 stroke-2" />
+                    <SquareChartGantt className="w-8 h-8 text-blue-400 stroke-2" />
                   </div>
                   <h2 className="text-2xl md:text-3xl font-bold text-gray-800 tracking-wide">
                     生成されたレポート


### PR DESCRIPTION
# 変更の概要
デザインの微妙なズレを修正
* テーマエリアの背景の円を右上固定に
* レポートのアイコンを修正

# スクリーンショット
<img width="1516" height="884" alt="image" src="https://github.com/user-attachments/assets/6668e545-10e1-4c98-8069-6b55ee169657" />


# 変更の背景
https://dd2030.slack.com/archives/C08FF5MM59C/p1754323222466159?thread_ts=1754319579.335189&cid=C08FF5MM59C

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
