### PR TITLE
Update: パンくずに不要なパスが出ないようにする

### DIFF
--- a/frontend/src/pages/QuestionDetail.tsx
+++ b/frontend/src/pages/QuestionDetail.tsx
@@ -120,8 +120,6 @@ const QuestionDetail = () => {
     };
 
     const breadcrumbItems = [
-      { label: "テーマ一覧", href: "/themes" },
-      { label: themeData.title, href: `/themes/${themeId}` },
       {
         label: questionData.tagLine || questionData.question,
         href: `/themes/${themeId}/questions/${qId}`,


### PR DESCRIPTION
# 変更の概要
パンくずで「テーマ一覧」「テーマ詳細」を出ないようにしてアクセスするページをシンプルにした

# スクリーンショット
<img width="1405" height="918" alt="image" src="https://github.com/user-attachments/assets/1f23ec0a-4642-4fa0-adb5-b6c3674a8335" />


# 変更の背景
<!-- ここに変更が必要となった背景を記載してください -->

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
