### PR TITLE
Update: SPで一括でパンくずを非表示に

### DIFF
--- a/frontend/src/components/common/BreadcrumbView.tsx
+++ b/frontend/src/components/common/BreadcrumbView.tsx
@@ -1,5 +1,6 @@
 import { Home } from "lucide-react";
 import { Link } from "../../contexts/MockContext";
+import { useMediaQuery } from "../../hooks/useMediaQuery";
 
 interface BreadcrumbItem {
   label: string;
@@ -12,6 +13,12 @@ interface BreadcrumbViewProps {
 }
 
 export function BreadcrumbView({ items, homeHref = "/" }: BreadcrumbViewProps) {
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  if (!isDesktop) {
+    return null;
+  }
+
   return (
     <nav className="text-left py-2" aria-label="Breadcrumb">
       <div className="inline text-[10px] leading-[1.5] tracking-[0.03em]">

--- a/frontend/src/components/theme/ThemeDetailTemplate.tsx
+++ b/frontend/src/components/theme/ThemeDetailTemplate.tsx
@@ -129,7 +129,7 @@ const ThemeDetailTemplate = forwardRef<
 
     return (
       <div className="container mx-auto px-6 py-8">
-        <div className="hidden md:block">
+        <div>
           <BreadcrumbView items={breadcrumbItems} />
         </div>
 

--- a/frontend/src/pages/QuestionDetail.tsx
+++ b/frontend/src/pages/QuestionDetail.tsx
@@ -129,7 +129,7 @@ const QuestionDetail = () => {
     return (
       <>
         <div className="xl:mr-[480px]">
-          <div className="hidden md:block px-6">
+          <div className="px-6">
             <BreadcrumbView items={breadcrumbItems} />
           </div>
           <div className="px-6 py-8">


### PR DESCRIPTION
# 変更の概要
SPにおいて、パンくずが全ページで出ないようにした

# スクリーンショット
<!-- UIの変更を伴う場合は、変更前後のスクリーンショットもしくはgif画像をこちらに記載してください -->

# 変更の背景
<!-- ここに変更が必要となった背景を記載してください -->

# 関連Issue
<!-- 関連するIssueのリンクをこちらに記載してください -->

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
