### PR TITLE
Update: QuestionDetailのテーマタイトル表示を改善

### DIFF
--- a/frontend/src/pages/QuestionDetail.tsx
+++ b/frontend/src/pages/QuestionDetail.tsx
@@ -99,9 +99,11 @@ const QuestionDetail = () => {
       voteCount: questionDetail?.question?.voteCount ?? 0,
     };
 
+    const questionTitle = questionData.tagLine || questionData.question || "";
+
     const themeData = {
       id: themeId || "",
-      title: themeInfo?.theme?.title || "テーマ",
+      title: questionTitle || themeInfo?.theme?.title || "テーマ",
     };
 
     const opinions = {
@@ -121,7 +123,7 @@ const QuestionDetail = () => {
 
     const breadcrumbItems = [
       {
-        label: questionData.tagLine || questionData.question,
+        label: questionTitle,
         href: `/themes/${themeId}/questions/${qId}`,
       },
     ];


### PR DESCRIPTION
## Summary
- QuestionDetailコンポーネントでquestionTitleを一元的に管理
- パンくずリストとテーマデータで同じタイトル表示ロジックを使用

## Test plan
- QuestionDetailページでテーマタイトルが正しく表示されることを確認
- パンくずリストのタイトルが適切に表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)