### PR TITLE
Remove footer link from About page

### DIFF
--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -16,15 +16,6 @@ const About = () => {
       ) : (
         <MarkdownRenderer markdown={siteConfig?.aboutMessage || ""} />
       )}
-
-      <div className="text-center mt-12">
-        <a
-          href="https://xxparty-policy.com"
-          className="text-sm text-neutral-500 hover:text-neutral-700"
-        >
-          © xxparty-policy.com
-        </a>
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
Removed footer link to xxparty-policy.com from About page.

# 変更の概要
https://kaigi.team-mir.ai/about
ここに表示されている `[© xxparty-policy.com](https://xxparty-policy.com/)` を削除します。
ページ下部のフッター部に `© 2025 デジタル民主主義2030` の表示があるので、消すだけでOK

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
