### PR TITLE
トップページ表示と GitHub App 秘密鍵設定を改善

### DIFF
--- a/frontend/src/components/home/FeaturedQuestionsSection.tsx
+++ b/frontend/src/components/home/FeaturedQuestionsSection.tsx
@@ -13,6 +13,7 @@ interface FeaturedQuestion {
   themeId?: string;
   tags?: string[];
   tagLine?: string;
+  href?: string;
 }
 
 interface FeaturedQuestionsSectionProps {
@@ -104,20 +105,18 @@ const FeaturedQuestionsSection = ({
             style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
           >
             {questions.map((question) => {
+              const linkTo =
+                question.href ??
+                (question.themeId
+                  ? `/themes/${question.themeId}/questions/${question.id}`
+                  : `/sharp-questions/${question.id}`);
               return (
                 <div
                   key={question.id}
                   className="featured-card flex-none w-[280px] h-[300px] snap-center"
                 >
                   <Card className="border p-4 border-blue-400 rounded-lg hover:shadow-sm transition-all duration-200 bg-white overflow-hidden h-full">
-                    <Link
-                      to={
-                        question.themeId
-                          ? `/themes/${question.themeId}/questions/${question.id}`
-                          : `/sharp-questions/${question.id}`
-                      }
-                      className="block h-full"
-                    >
+                    <Link to={linkTo} className="block h-full">
                       <div className="flex flex-col h-full">
                         <div className="flex-1 p-0">
                           <h3 className="font-bold text-base text-gray-900 mb-3 leading-tight">

--- a/frontend/src/components/home/HeroSection.tsx
+++ b/frontend/src/components/home/HeroSection.tsx
@@ -5,6 +5,11 @@ import { Button } from "../ui/button";
 import { Select } from "../ui/select";
 
 interface HeroSectionProps {
+  latestThemes?: {
+    _id: string;
+    title: string;
+    description?: string;
+  }[];
   latestQuestions?: {
     _id: string;
     questionText: string;
@@ -13,24 +18,40 @@ interface HeroSectionProps {
   }[];
 }
 
-const HeroSection = ({ latestQuestions = [] }: HeroSectionProps) => {
+const HeroSection = ({
+  latestThemes = [],
+  latestQuestions = [],
+}: HeroSectionProps) => {
   const [selectedQuestion, setSelectedQuestion] = useState("");
   const navigate = useNavigate();
+  const hasQuestions = latestQuestions.length > 0;
 
   const handleStartDialogue = () => {
-    if (selectedQuestion) {
+    if (!selectedQuestion) return;
+    if (hasQuestions) {
       const question = latestQuestions.find((q) => q._id === selectedQuestion);
       if (question?.themeId) {
         navigate(`/themes/${question.themeId}/questions/${selectedQuestion}`);
       }
+      return;
+    }
+
+    const theme = latestThemes.find((t) => t._id === selectedQuestion);
+    if (theme) {
+      navigate(`/themes/${theme._id}`);
     }
   };
 
   // Format options for the select dropdown
-  const questionOptions = latestQuestions.map((q) => ({
-    value: q._id,
-    label: q.tagLine || `${q.questionText.substring(0, 50)}...`,
-  }));
+  const questionOptions = hasQuestions
+    ? latestQuestions.map((q) => ({
+        value: q._id,
+        label: q.tagLine || `${q.questionText.substring(0, 50)}...`,
+      }))
+    : latestThemes.map((theme) => ({
+        value: theme._id,
+        label: theme.title,
+      }));
 
   return (
     <div className="relative py-12 overflow-hidden rounded-b-3xl">

--- a/frontend/src/components/home/QuestionsTable.tsx
+++ b/frontend/src/components/home/QuestionsTable.tsx
@@ -14,6 +14,7 @@ interface Question {
   description?: string;
   participantCount?: number;
   commentCount?: number;
+  href?: string;
 }
 
 interface QuestionsTableProps {
@@ -44,10 +45,13 @@ const QuestionsTable = ({ questions }: QuestionsTableProps) => {
             style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
           >
             {questions.map((question) => {
+              const linkTo =
+                question.href ??
+                `/themes/${question.themeId}/questions/${question.id}`;
               return (
                 <Link
                   key={question.id}
-                  to={`/themes/${question.themeId}/questions/${question.id}`}
+                  to={linkTo}
                   className="question-item block"
                 >
                   <Card className="md:h-[60px] h-auto p-0 border border-blue-400 rounded-lg hover:shadow-sm transition-all duration-200 bg-blue-50">

--- a/frontend/src/components/top/TopPageTemplate.tsx
+++ b/frontend/src/components/top/TopPageTemplate.tsx
@@ -6,6 +6,14 @@ import OpinionsSection from "../home/OpinionsSection";
 import QuestionsTable from "../home/QuestionsTable";
 
 export interface TopPageTemplateProps {
+  latestThemes?: {
+    _id: string;
+    title: string;
+    description?: string;
+    slug?: string;
+    keyQuestionCount?: number;
+    commentCount?: number;
+  }[];
   latestQuestions?: {
     _id: string;
     questionText: string;
@@ -22,31 +30,44 @@ export interface TopPageTemplateProps {
 }
 
 const TopPageTemplate = ({
+  latestThemes = [],
   latestQuestions = [],
   latestOpinions = [],
 }: TopPageTemplateProps) => {
+  const hasQuestions = latestQuestions.length > 0;
+  const themesAsQuestions = latestThemes.map((theme) => ({
+    id: theme._id,
+    title: theme.title,
+    description: theme.title,
+    participantCount: theme.commentCount || 0,
+    commentCount: theme.keyQuestionCount || 0,
+    href: `/themes/${theme._id}`,
+  }));
+
   const maxFeaturedQuestions = 70;
-  const featuredQuestions = latestQuestions
-    .map((q) => ({
-      id: q._id,
-      title: q.questionText,
-      description: q.tagLine || `${q.questionText.substring(0, 100)}...`,
-      participantCount: q.uniqueParticipantCount || 0,
-      commentCount: q.issueCount || 0 + (q.solutionCount || 0),
-      likeCount: q.likeCount || 0,
-      themeId: q.themeId,
-      tags: q.tags || [],
-    }))
-    .sort(
-      (a, b) =>
-        (b.participantCount || 0) +
-        (b.commentCount || 0) +
-        (b.likeCount || 0) -
-        (a.participantCount || 0) -
-        (a.commentCount || 0) -
-        (a.likeCount || 0)
-    )
-    .slice(0, maxFeaturedQuestions);
+  const featuredQuestions = hasQuestions
+    ? latestQuestions
+        .map((q) => ({
+          id: q._id,
+          title: q.tagLine || "お題",
+          description: q.questionText,
+          participantCount: q.uniqueParticipantCount || 0,
+          commentCount: q.issueCount || 0 + (q.solutionCount || 0),
+          likeCount: q.likeCount || 0,
+          themeId: q.themeId,
+          tags: q.tags || [],
+        }))
+        .sort(
+          (a, b) =>
+            (b.participantCount || 0) +
+            (b.commentCount || 0) +
+            (b.likeCount || 0) -
+            (a.participantCount || 0) -
+            (a.commentCount || 0) -
+            (a.likeCount || 0)
+        )
+        .slice(0, maxFeaturedQuestions)
+    : themesAsQuestions.slice(0, maxFeaturedQuestions);
 
   return (
     <div className="min-h-screen bg-white">
@@ -54,26 +75,45 @@ const TopPageTemplate = ({
         <BreadcrumbView items={[]} />
       </div>
 
-      <HeroSection latestQuestions={latestQuestions} />
+      <HeroSection
+        latestThemes={latestThemes}
+        latestQuestions={latestQuestions}
+      />
 
       <OpinionsSection opinions={latestOpinions} />
 
       <FeaturedQuestionsSection questions={featuredQuestions} />
 
       <QuestionsTable
-        questions={latestQuestions.map((q) => ({
-          id: q._id,
-          category: q.tagLine || "未分類",
-          title: q.questionText,
-          questionText: q.questionText,
-          postCount: (q.issueCount || 0) + (q.solutionCount || 0),
-          lastUpdated: q.createdAt || new Date().toISOString(),
-          themeId: q.themeId,
-          tagLine: q.tagLine,
-          description: q.tagLine || `${q.questionText.substring(0, 100)}...`,
-          participantCount: q.uniqueParticipantCount || 0,
-          commentCount: q.issueCount || 0 + (q.solutionCount || 0),
-        }))}
+        questions={
+          hasQuestions
+            ? latestQuestions.map((q) => ({
+                id: q._id,
+                category: q.tagLine || "未分類",
+                title: q.questionText,
+                questionText: q.questionText,
+                postCount: (q.issueCount || 0) + (q.solutionCount || 0),
+                lastUpdated: q.createdAt || new Date().toISOString(),
+                themeId: q.themeId,
+                tagLine: q.tagLine,
+                description: q.questionText,
+                participantCount: q.uniqueParticipantCount || 0,
+                commentCount: q.issueCount || 0 + (q.solutionCount || 0),
+              }))
+            : themesAsQuestions.map((theme) => ({
+                id: theme.id,
+                category: "テーマ",
+                title: theme.title,
+                questionText: theme.title,
+                postCount: theme.commentCount || 0,
+                lastUpdated: new Date().toISOString(),
+                themeId: theme.id,
+                description: theme.title,
+                participantCount: theme.participantCount || 0,
+                commentCount: theme.commentCount || 0,
+                href: theme.href,
+              }))
+        }
       />
     </div>
   );

--- a/frontend/src/pages/Top.tsx
+++ b/frontend/src/pages/Top.tsx
@@ -14,33 +14,9 @@ const Top = () => {
   const [isLoading, setIsLoading] = useState(!isMockMode);
   const [error, setError] = useState<string | null>(null);
 
-  const mockDiscussionData = [
-    {
-      id: 1,
-      title: "どうすれば若者が安心してキャリアを築ける社会を実現できるか？",
-      problemCount: 99,
-      solutionCount: 99,
-      likeCount: 99,
-    },
-    {
-      id: 2,
-      title: "どうすれば若者が安心してキャリアを築ける社会を実現できるか？",
-      problemCount: 99,
-      solutionCount: 99,
-      likeCount: 99,
-    },
-    {
-      id: 3,
-      title: "どうすれば若者が安心してキャリアを築ける社会を実現できるか？",
-      problemCount: 99,
-      solutionCount: 99,
-      likeCount: 99,
-    },
-  ];
-
   const mockThemeData = [
     {
-      id: "1",
+      _id: "1",
       title: "どうすれば若者が安心してキャリアを築ける社会を実現できるか？",
       description:
         "どうすれば若者が安心してキャリアを築ける社会を実現できるか？",
@@ -48,7 +24,7 @@ const Top = () => {
       commentCount: 99,
     },
     {
-      id: "2",
+      _id: "2",
       title: "どうすれば若者が安心してキャリアを築ける社会を実現できるか？",
       description:
         "どうすれば若者が安心してキャリアを築ける社会を実現できるか？",
@@ -56,7 +32,7 @@ const Top = () => {
       commentCount: 99,
     },
     {
-      id: "3",
+      _id: "3",
       title: "どうすれば若者が安心してキャリアを築ける社会を実現できるか？",
       description:
         "どうすれば若者が安心してキャリアを築ける社会を実現できるか？",
@@ -164,12 +140,12 @@ const Top = () => {
   if (isMockMode || topPageData) {
     const templateProps = isMockMode
       ? {
-          discussions: mockDiscussionData,
-          themes: mockThemeData,
-          questions: mockQuestions,
+          latestThemes: mockThemeData,
+          latestQuestions: mockQuestions,
           latestOpinions: [], // Mock mode doesn't have opinions yet
         }
       : {
+          latestThemes: topPageData?.latestThemes || [],
           latestQuestions: topPageData?.latestQuestions || [],
           latestOpinions: topPageData?.latestOpinions || [],
         };

--- a/frontend/src/services/api/httpClient.ts
+++ b/frontend/src/services/api/httpClient.ts
@@ -75,6 +75,9 @@ export class HttpClient {
         ...headers,
       },
     };
+    if (method === "GET") {
+      options.cache = "no-store";
+    }
 
     if (data) {
       options.body = JSON.stringify(data);

--- a/idea-discussion/backend/models/Problem.ts
+++ b/idea-discussion/backend/models/Problem.ts
@@ -3,23 +3,47 @@ import { IProblem } from "../types/index.js";
 
 const problemSchema = new Schema<IProblem>(
   {
+    statement: {
+      // 単体で理解可能な課題文
+      type: String,
+      required: true,
+    },
+    sourceOriginId: {
+      // 抽出元の `chat_threads` ID または `imported_items` ID
+      type: Schema.Types.ObjectId,
+      required: true,
+    },
+    sourceType: {
+      // データソース種別
+      type: String,
+      required: true,
+    },
+    originalSnippets: {
+      // (任意) 抽出の元になったユーザー発言の断片
+      type: [String],
+      default: [],
+    },
+    sourceMetadata: {
+      // (任意) ソースに関する追加情報 (例: tweet ID, URL, author)
+      type: Object,
+      default: {},
+    },
+    version: {
+      // 更新版管理用バージョン番号
+      type: Number,
+      required: true,
+      default: 1,
+    },
     themeId: {
+      // 追加：所属するテーマのID
       type: Schema.Types.ObjectId,
-      required: true,
       ref: "Theme",
-    },
-    content: {
-      type: String,
       required: true,
     },
-    source: {
-      type: String,
-      required: true,
-    },
-    extractedFrom: {
-      type: Schema.Types.ObjectId,
-      required: false,
-      ref: "ChatThread",
+    embeddingGenerated: {
+      type: Boolean,
+      default: false,
+      index: true,
     },
   },
   { timestamps: true }

--- a/idea-discussion/backend/models/SharpQuestion.ts
+++ b/idea-discussion/backend/models/SharpQuestion.ts
@@ -8,7 +8,7 @@ const sharpQuestionSchema = new Schema<ISharpQuestion>(
       required: true,
       ref: "Theme",
     },
-    content: {
+    questionText: {
       type: String,
       required: true,
     },
@@ -20,9 +20,16 @@ const sharpQuestionSchema = new Schema<ISharpQuestion>(
       type: [String],
       default: [],
     },
-    order: {
-      type: Number,
-      required: false,
+    sourceProblemIds: [
+      {
+        type: Schema.Types.ObjectId,
+        ref: "Problem",
+      },
+    ],
+    clusteringResults: {
+      type: Map,
+      of: Object,
+      default: {},
     },
   },
   { timestamps: true }

--- a/idea-discussion/backend/models/Solution.ts
+++ b/idea-discussion/backend/models/Solution.ts
@@ -3,23 +3,47 @@ import { ISolution } from "../types/index.js";
 
 const solutionSchema = new Schema<ISolution>(
   {
+    statement: {
+      // 解決策の具体的な手段
+      type: String,
+      required: true,
+    },
+    sourceOriginId: {
+      // 抽出元の `chat_threads` ID または `imported_items` ID
+      type: Schema.Types.ObjectId,
+      required: true,
+    },
+    sourceType: {
+      // データソース種別
+      type: String,
+      required: true,
+    },
+    originalSnippets: {
+      // (任意) 抽出の元になったユーザー発言の断片
+      type: [String],
+      default: [],
+    },
+    sourceMetadata: {
+      // (任意) ソースに関する追加情報 (例: tweet ID, URL, author)
+      type: Object,
+      default: {},
+    },
+    version: {
+      // 更新版管理用バージョン番号
+      type: Number,
+      required: true,
+      default: 1,
+    },
     themeId: {
+      // 追加：所属するテーマのID
       type: Schema.Types.ObjectId,
-      required: true,
       ref: "Theme",
-    },
-    content: {
-      type: String,
       required: true,
     },
-    source: {
-      type: String,
-      required: true,
-    },
-    extractedFrom: {
-      type: Schema.Types.ObjectId,
-      required: false,
-      ref: "ChatThread",
+    embeddingGenerated: {
+      type: Boolean,
+      default: false,
+      index: true,
     },
   },
   { timestamps: true }

--- a/idea-discussion/backend/types/index.ts
+++ b/idea-discussion/backend/types/index.ts
@@ -14,24 +14,33 @@ export interface ITheme extends BaseDocument {
 
 export interface ISharpQuestion extends BaseDocument {
   themeId: Types.ObjectId;
-  content: string;
+  questionText: string;
   tagLine?: string;
   tags?: string[];
-  order?: number;
+  sourceProblemIds?: Types.ObjectId[];
+  clusteringResults?: Record<string, unknown>;
 }
 
 export interface IProblem extends BaseDocument {
   themeId: Types.ObjectId;
-  content: string;
-  source: string;
-  extractedFrom?: Types.ObjectId;
+  statement: string;
+  sourceOriginId: Types.ObjectId;
+  sourceType: string;
+  originalSnippets?: string[];
+  sourceMetadata?: Record<string, unknown>;
+  version: number;
+  embeddingGenerated?: boolean;
 }
 
 export interface ISolution extends BaseDocument {
   themeId: Types.ObjectId;
-  content: string;
-  source: string;
-  extractedFrom?: Types.ObjectId;
+  statement: string;
+  sourceOriginId: Types.ObjectId;
+  sourceType: string;
+  originalSnippets?: string[];
+  sourceMetadata?: Record<string, unknown>;
+  version: number;
+  embeddingGenerated?: boolean;
 }
 
 export interface IChatMessage {

--- a/policy-edit/backend/src/index.ts
+++ b/policy-edit/backend/src/index.ts
@@ -1,12 +1,4 @@
-// --- DEBUG: Print GitHub Env Vars ---
-console.log("--- GitHub Environment Variables ---");
-console.log("GITHUB_APP_ID:", process.env.GITHUB_APP_ID);
-console.log("GITHUB_INSTALLATION_ID:", process.env.GITHUB_INSTALLATION_ID);
-console.log("GITHUB_TARGET_OWNER:", process.env.GITHUB_TARGET_OWNER);
-console.log("GITHUB_TARGET_REPO:", process.env.GITHUB_TARGET_REPO);
-console.log("------------------------------------");
 import cors from "cors";
-// --- END DEBUG ---
 import express from "express";
 import { CORS_ORIGIN, PORT } from "./config.js";
 import chatRoutes from "./routes/chat.js";

--- a/policy-edit/mcp/src/github/client.ts
+++ b/policy-edit/mcp/src/github/client.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import path from "node:path";
 import { App } from "@octokit/app";
 import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
 import type { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods"; // Use the documented type export
@@ -19,7 +18,20 @@ let installationOctokit: InstallationOctokit | null = null;
 // tokenExpiration is removed as getInstallationOctokit likely handles token refresh.
 
 function getPrivateKey(): string {
-  const keyPath = "/app/secrets/github-key.pem"; // Fixed path inside the container
+  const keyFromEnv = process.env.GITHUB_APP_PRIVATE_KEY;
+  if (typeof keyFromEnv === "string" && keyFromEnv.trim() !== "") {
+    logger.info("Using GitHub App private key from env var.");
+    return keyFromEnv;
+  }
+
+  const keyFromEnvBase64 = process.env.GITHUB_APP_PRIVATE_KEY_BASE64;
+  if (typeof keyFromEnvBase64 === "string" && keyFromEnvBase64.trim() !== "") {
+    logger.info("Using GitHub App private key from base64 env var.");
+    return Buffer.from(keyFromEnvBase64, "base64").toString("utf8");
+  }
+
+  const keyPath =
+    process.env.GITHUB_APP_PRIVATE_KEY_PATH ?? "/app/secrets/github-key.pem";
   try {
     logger.info(`Reading private key from file: ${keyPath}`);
     return fs.readFileSync(keyPath, "utf8");


### PR DESCRIPTION
## 概要

この PR は、ホスティングサービスに依存しない範囲で、トップページ表示、API 取得、GitHub App 秘密鍵の扱い、idea-discussion のデータ型を改善します。

特定のデプロイ先に合わせた設定は含めていないため、既存の開発環境や本番環境の選択肢を狭めずに取り込める内容です。

## 変更内容

- 最新の質問がない場合でも、最新テーマを使ってトップページを表示・遷移できるようにしました
- 質問カード・テーマカード・一覧で `href` を受け取れるようにし、リンク先指定を柔軟にしました
- frontend の共通 HTTP client で GET リクエストに `cache: "no-store"` を指定し、古いレスポンスが表示されるリスクを下げました
- GitHub App の秘密鍵を、環境変数・base64 環境変数・設定可能なファイルパスから読めるようにしました
- 起動時に GitHub 関連の環境変数を出力していた debug log を削除しました
- `idea-discussion` の `Problem` / `Solution` / `SharpQuestion` の schema と TypeScript 型を拡張しました

## 含めていないもの

- Vercel 固有の rewrite 設定
- Railway 固有の Dockerfile 調整
- デプロイ環境専用の entrypoint script
- production container で frontend 静的ファイルを配信するための変更

## レビュー観点

- `idea-discussion` の schema/type 変更は既存データや API 利用箇所に影響し得るため、フィールド名と required 指定が意図どおりか確認したいです
- GET 全体に `cache: "no-store"` を付ける方針が、パフォーマンスより最新性を優先する判断として妥当か確認したいです
- GitHub App 秘密鍵の読み込み順序が運用上扱いやすいか確認したいです

## 検証

以下を実行し、すべて成功しています。

- `npm run typecheck --workspace=idobata-frontend`
- `npm run typecheck --workspace=idobata-idea-discussion-backend`
- `npm run typecheck --workspace=idobata-policy-editor-backend`
- `npm run typecheck --workspace=github-contribution-mcp`
- `npm run test --workspace=idobata-frontend`
- `npm run test --workspace=idobata-idea-discussion-backend`
- `npm run test --workspace=idobata-policy-editor-backend`
- `npm run test --workspace=github-contribution-mcp`
- `npm run lint --workspace=idobata-frontend`
- `npm run lint --workspace=idobata-idea-discussion-backend`
- `npm run lint --workspace=idobata-policy-editor-backend`
- `npm run lint --workspace=github-contribution-mcp`