### PR TITLE
fix: postgres:latest 更新に伴うエラー回避

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,13 +89,14 @@ services:
       - POLICY_CORS_ORIGIN=${POLICY_CORS_ORIGIN}
       - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-password}@postgres-policy:5432/${POSTGRES_DB:-policy_db}
     depends_on:
-      - postgres-policy
+      postgres-policy:
+        condition: service_healthy
     # Run the production start command
     command: npm start
 
   postgres-policy:
     container_name: postgres-policy-dev
-    image: postgres:latest
+    image: postgres:17
     ports:
       - "5433:5432" # Expose to host port 5433 to avoid conflict if local 5432 is used
     environment:


### PR DESCRIPTION
## 変更の概要
開発時から時間が経過し `postgres:latest` が 18系になったことで、`postgres-policy` が起動時に以下のエアーで停止してしまうようです。
この影響を回避し、まずは既存の開発フローを安定して動かすため、Policy Edit で利用する PostgreSQL イメージを 17系に固定します。
あわせて、バックエンドがDB起動完了前に立ち上がるレースコンディションを防ぐため、policy-backend の起動条件に `postgres-policy` のヘルスチェック待機を追加します。

PostgreSQL 18系への追従対応は、本PRでは扱わず、必要に応じて別PRで実施します。

```
postgres-policy-dev  | Error: in 18+, these Docker images are configured to store database data in a
postgres-policy-dev  |        format which is compatible with "pg_ctlcluster" (specifically, using
postgres-policy-dev  |        major-version-specific directory names).  This better reflects how
postgres-policy-dev  |        PostgreSQL itself works, and how upgrades are to be performed.
postgres-policy-dev  | 
postgres-policy-dev  |        See also https://github.com/docker-library/postgres/pull/1259
postgres-policy-dev  | 
postgres-policy-dev  |        Counter to that, there appears to be PostgreSQL data in:
postgres-policy-dev  |          /var/lib/postgresql/data (unused mount/volume)
postgres-policy-dev  | 
postgres-policy-dev  |        This is usually the result of upgrading the Docker image without
postgres-policy-dev  |        upgrading the underlying database using "pg_upgrade" (which requires both
postgres-policy-dev  |        versions).
postgres-policy-dev  | 
postgres-policy-dev  |        The suggested container configuration for 18+ is to place a single mount
postgres-policy-dev  |        at /var/lib/postgresql which will then place PostgreSQL data in a
postgres-policy-dev  |        subdirectory, allowing usage of "pg_upgrade --link" without mount point
postgres-policy-dev  |        boundary issues.
postgres-policy-dev  | 
postgres-policy-dev  |        See https://github.com/docker-library/postgres/issues/37 for a (long)
postgres-policy-dev  |        discussion around this process, and suggestions for how to do so.
```

## 変更内容
- postgres-policy のイメージを postgres:latest から postgres:17 へ変更
- policy-backend の depends_on を service_healthy 条件付きへ変更

## 期待効果
- latest 追従に伴う想定外の互換性問題を回避
- PostgreSQL準備完了前のバックエンド起動を防止

## 影響範囲
- docker-compose の Policy Edit 関連サービス定義のみ

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
