### PR TITLE
docs: Policy Edit の DB 起動手順と migration 手順を development-setup に追記

### DIFF
--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -92,12 +92,32 @@ docker-compose up --build -d frontend idea-backend mongo
 
 ### Policy Edit のみ起動
 
-`policy-edit` のフロントエンドとバックエンドのみを起動する場合（データベースは使用しません）：
+`policy-edit` のフロントエンド、バックエンド、および PostgreSQL を起動する場合：
 
 ```bash
 # 必要なセットアップ: Policy Edit セットアップ
-docker-compose up --build -d policy-frontend policy-backend
+docker-compose up --build -d policy-frontend policy-backend postgres-policy
 ```
+
+### Policy Edit のデータベース migration
+
+`policy-backend` は PostgreSQL を使用します。初回起動時、または `interaction_logs` などのテーブルが存在しないエラーが出る場合は migration を実行してください。
+
+```bash
+cd policy-edit/backend
+npm install
+DATABASE_URL=postgresql://postgres:password@localhost:5433/policy_db npm run db:migrate
+cd ../..
+docker-compose restart policy-backend
+```
+
+migration 後、テーブル作成を以下で確認できます。
+
+```bash
+docker-compose exec postgres-policy psql -U postgres -d policy_db -c '\dt'
+```
+
+`Failed to log interaction: relation "interaction_logs" does not exist` が出る場合は、上記 migration が完了しているかを確認してください。
 
 ## アプリケーションへのアクセス
 


### PR DESCRIPTION
## 変更の概要
Policy Edit の開発手順に、実態と異なる記載があったため修正します。
あわせて、初回起動時に必要な migration 手順を追記し、interaction_logs テーブル未作成時の対処が分かるようにします。

## 変更内容
- Policy Edit 起動手順を修正（PostgreSQL サービスを含める）
- migration 実行手順を追記
- テーブル作成確認手順を追記
- relation interaction_logs does not exist エラー時の確認ポイントを追記

## 期待効果
初回セットアップ時の詰まりどころを減らす
テーブル未作成によるエラーを自己解決しやすくする

## 影響範囲
`development-setup.md` のみ

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
