### PR TITLE
refactor: 使用していない crypto を削除 (#448 をディレクトリ整理後に再適用)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5205,13 +5205,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.",
-      "license": "ISC"
-    },
     "node_modules/css-select": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -14158,7 +14151,6 @@
         "axios": "^1.9.0",
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
-        "crypto": "^1.0.1",
         "dotenv": "^16.4.7",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",

--- a/vision/idea-discussion/backend/models/AdminUser.js
+++ b/vision/idea-discussion/backend/models/AdminUser.js
@@ -1,4 +1,3 @@
-import crypto from "node:crypto";
 import bcrypt from "bcryptjs";
 import mongoose from "mongoose";
 

--- a/vision/idea-discussion/backend/package.json
+++ b/vision/idea-discussion/backend/package.json
@@ -21,7 +21,6 @@
     "axios": "^1.9.0",
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
-    "crypto": "^1.0.1",
     "dotenv": "^16.4.7",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",


### PR DESCRIPTION
# 変更の概要

使用していない `crypto` パッケージを削除します。#448（@noritaka1166）の内容を、ディレクトリ整理（`idea-discussion/` → `vision/idea-discussion/`）後の現行 main に対して再適用したものです。

- `vision/idea-discussion/backend/package.json` から `"crypto": "^1.0.1"` を削除
- `vision/idea-discussion/backend/models/AdminUser.js` の未使用 import `import crypto from "node:crypto";` を削除
- `package-lock.json` から `crypto` 関連エントリを削除

# スクリーンショット
なし（UI 変更なし）

# 変更の背景

#448 がディレクトリ大幅整理（#501）によりコンフリクトしてマージ不能になっていたため、指摘内容の妥当性を確認のうえ、新パスへ同等の変更を適用しました。

指摘は妥当です:
- npm の `crypto` パッケージは deprecated（`This package is no longer supported. It's now a built-in Node module.`）で、Node 組み込みの `node:crypto` を使うべきもの
- `AdminUser.js` の `import crypto from "node:crypto";` は宣言のみで未使用（ファイル内で `crypto` を参照していない）

`npm run lint` / `npm run typecheck` / `npm run test` が通ることを確認済みです。

# 関連Issue

- #448 を置き換えます（同 PR はディレクトリ整理によりコンフリクト）

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

Link to Devin session: https://app.devin.ai/sessions/a1ea854c2d4b4a57829881a768247c23
Requested by: @kuboon