### PR TITLE
feat(policy): GITHUB_TARGET_PATH で対象を特定フォルダ以下に限定できるように

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -47,6 +47,11 @@ GITHUB_TARGET_REPO=your_target_repository_name_here
 # プルリクエスト作成時のベースとなるブランチ名です。(省略可能、デフォルトブランチが使われることが多い)
 GITHUB_BASE_BRANCH=main # Or your default branch
 
+# いどばた政策(policy)で閲覧・編集の対象をリポジトリ内の特定サブフォルダに限定したい場合に設定します。
+# 例: GITHUB_TARGET_PATH=docs/policies とすると、そのフォルダ配下だけが閲覧・編集・PR 作成の対象になります。
+# 空 (未設定) の場合はリポジトリ全体が対象です。(policy-frontend / policy-backend の双方に適用されます)
+GITHUB_TARGET_PATH=
+
 # GitHub Mock Client Configuration
 # true にすると、いどばた政策のフロントエンドが実際の GitHub API を呼ばずモックを使用します。
 # GitHub App を用意せずに UI を試したい場合（お試し構成）は true に設定してください。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,8 @@ services:
       # Map GITHUB_TARGET_* from .env to VITE_GITHUB_* for the frontend
       - VITE_GITHUB_REPO_OWNER=${GITHUB_TARGET_OWNER}
       - VITE_GITHUB_REPO_NAME=${GITHUB_TARGET_REPO}
+      # Restrict browsing/editing to a subdirectory (empty = whole repo)
+      - VITE_GITHUB_TARGET_PATH=${GITHUB_TARGET_PATH}
       - VITE_POLICY_FRONTEND_ALLOWED_HOSTS=${VITE_POLICY_FRONTEND_ALLOWED_HOSTS}
       # GitHub Mock Client Configuration
       - VITE_USE_MOCK_GITHUB_CLIENT=${VITE_USE_MOCK_GITHUB_CLIENT}

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -113,6 +113,7 @@
     - `GITHUB_TARGET_OWNER`: 対象リポジトリのオーナー名 (バックエンド・フロントエンドで使用)
     - `GITHUB_TARGET_REPO`: 対象リポジトリ名 (バックエンド・フロントエンドで使用)
     - `GITHUB_BASE_BRANCH`: 対象リポジトリのベースブランチ名 (バックエンドで使用)
+    - `GITHUB_TARGET_PATH`: いどばた政策の閲覧・編集対象をリポジトリ内の特定サブフォルダに限定したい場合に設定します（例: `docs/policies`）。空の場合はリポジトリ全体が対象です。バックエンド（書き込み・PR）とフロントエンド（閲覧）の双方に適用されます。
     - `POLICY_FRONTEND_API_BASE_URL`: フロントエンドがアクセスするバックエンド API の URL（通常は `http://localhost:3001`）
     - `VITE_USE_MOCK_GITHUB_CLIENT`: `true` にするとフロントエンドが実際の GitHub API を呼ばずモッククライアントを使用します。お試し時は `true` を推奨します。
 

--- a/policy/backend/src/config.ts
+++ b/policy/backend/src/config.ts
@@ -26,6 +26,11 @@ export const GITHUB_INSTALLATION_ID = process.env.GITHUB_INSTALLATION_ID;
 export const GITHUB_TARGET_OWNER = process.env.GITHUB_TARGET_OWNER;
 export const GITHUB_TARGET_REPO = process.env.GITHUB_TARGET_REPO;
 export const GITHUB_BASE_BRANCH = process.env.GITHUB_BASE_BRANCH || "main";
+// Restrict read/write operations to this subdirectory of the target repo.
+// Empty (default) means the whole repository is targeted.
+export const GITHUB_TARGET_PATH = (process.env.GITHUB_TARGET_PATH || "")
+  .trim()
+  .replace(/^\/+|\/+$/g, "");
 export const GITHUB_API_BASE_URL = process.env.GITHUB_API_BASE_URL;
 export const GITHUB_PRIVATE_KEY_PATH =
   process.env.GITHUB_PRIVATE_KEY_PATH || "/app/secrets/github-key.pem";

--- a/policy/backend/src/github/paths.test.ts
+++ b/policy/backend/src/github/paths.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { resolveTargetPath } from "./paths.js";
+
+describe("resolveTargetPath", () => {
+  it("returns the path unchanged when no base path is set", () => {
+    expect(resolveTargetPath("docs/foo.md", "")).toBe("docs/foo.md");
+  });
+
+  it("strips a leading slash", () => {
+    expect(resolveTargetPath("/foo.md", "")).toBe("foo.md");
+  });
+
+  it("prefixes the base path", () => {
+    expect(resolveTargetPath("foo.md", "docs/policies")).toBe(
+      "docs/policies/foo.md"
+    );
+  });
+
+  it("prefixes nested relative paths", () => {
+    expect(resolveTargetPath("sub/foo.md", "docs/policies")).toBe(
+      "docs/policies/sub/foo.md"
+    );
+  });
+
+  it("returns the base path itself for an empty relative path", () => {
+    expect(resolveTargetPath("", "docs/policies")).toBe("docs/policies");
+  });
+
+  it("rejects paths that try to escape via ..", () => {
+    expect(() => resolveTargetPath("../secret.md", "docs/policies")).toThrow();
+    expect(() =>
+      resolveTargetPath("sub/../../secret.md", "docs/policies")
+    ).toThrow();
+  });
+});

--- a/policy/backend/src/github/paths.ts
+++ b/policy/backend/src/github/paths.ts
@@ -1,0 +1,29 @@
+import { GITHUB_TARGET_PATH } from "../config.js";
+
+/**
+ * フロントエンドから渡される (対象フォルダ相対の) ファイルパスを、
+ * GITHUB_TARGET_PATH を前置したリポジトリ絶対パスに解決する。
+ *
+ * - 先頭のスラッシュは除去する
+ * - `..` を含むパスはフォルダ外へのアクセスとみなして拒否する
+ * - GITHUB_TARGET_PATH が未設定の場合は従来どおりリポジトリ全体が対象
+ */
+export function resolveTargetPath(
+  relativePath: string,
+  basePath: string = GITHUB_TARGET_PATH
+): string {
+  const normalized = relativePath.replace(/^\/+/, "");
+
+  const segments = normalized.split("/");
+  if (segments.some((segment) => segment === "..")) {
+    throw new Error(
+      `Invalid path: "${relativePath}" must not contain '..' path segments`
+    );
+  }
+
+  if (!basePath) {
+    return normalized;
+  }
+
+  return normalized ? `${basePath}/${normalized}` : basePath;
+}

--- a/policy/backend/src/tools/upsertFile.ts
+++ b/policy/backend/src/tools/upsertFile.ts
@@ -1,5 +1,6 @@
 import { GITHUB_TARGET_OWNER, GITHUB_TARGET_REPO } from "../config.js";
 import { getAuthenticatedOctokit } from "../github/client.js";
+import { resolveTargetPath } from "../github/paths.js";
 import { ensureBranchExists } from "../github/utils.js";
 import { logger } from "../utils/logger.js";
 import { trimTrailingContentSeparators } from "../utils/stringUtils.js";
@@ -64,7 +65,9 @@ export async function handleUpsertFile(
   const { filePath, branchName, content, commitMessage } = params;
   const owner = GITHUB_TARGET_OWNER ?? "";
   const repo = GITHUB_TARGET_REPO ?? "";
-  const fullPath = filePath.startsWith("/") ? filePath.substring(1) : filePath;
+  // Scope the (folder-relative) path to GITHUB_TARGET_PATH so writes cannot
+  // escape the configured subdirectory.
+  const fullPath = resolveTargetPath(filePath);
 
   logger.info("Handling upsert_file_and_commit request", {
     owner,

--- a/policy/frontend/src/lib/github.test.ts
+++ b/policy/frontend/src/lib/github.test.ts
@@ -1,7 +1,15 @@
+import { ok } from "neverthrow";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type GitHubDirectoryItem, type GitHubFile } from "./github";
 import { GitHubClient } from "./github/GitHubClient";
-import type { IGitHubClient } from "./github/IGitHubClient";
+import type {
+  GitHubFile as GitHubFileType,
+  IGitHubClient,
+} from "./github/IGitHubClient";
+import {
+  ScopedGitHubClient,
+  normalizeTargetPath,
+} from "./github/ScopedGitHubClient";
 
 // global.fetch をモック
 const mockFetch = vi.fn();
@@ -299,5 +307,116 @@ describe("GitHubClient", () => {
 
       global.TextDecoder = originalTextDecoder;
     });
+  });
+});
+
+describe("normalizeTargetPath", () => {
+  it("returns empty string for undefined/empty", () => {
+    expect(normalizeTargetPath(undefined)).toBe("");
+    expect(normalizeTargetPath("")).toBe("");
+  });
+
+  it("strips leading and trailing slashes", () => {
+    expect(normalizeTargetPath("/docs/policies/")).toBe("docs/policies");
+    expect(normalizeTargetPath("docs/policies")).toBe("docs/policies");
+  });
+});
+
+describe("ScopedGitHubClient", () => {
+  const owner = "test-owner";
+  const repo = "test-repo";
+  const basePath = "docs/policies";
+
+  const makeFile = (path: string): GitHubFileType => ({
+    name: path.split("/").pop() || "",
+    path,
+    sha: "sha",
+    size: 1,
+    url: "",
+    html_url: "",
+    git_url: "",
+    download_url: null,
+    type: "file",
+    content: "",
+    encoding: "base64",
+    _links: { self: "", git: "", html: "" },
+  });
+
+  it("prefixes the requested path with the base path", async () => {
+    const inner: IGitHubClient = {
+      fetchContent: vi.fn().mockResolvedValue(ok(makeFile(`${basePath}/a.md`))),
+      decodeBase64Content: vi.fn(),
+    };
+    const client = new ScopedGitHubClient(inner, basePath);
+
+    await client.fetchContent(owner, repo, "a.md", "main");
+
+    expect(inner.fetchContent).toHaveBeenCalledWith(
+      owner,
+      repo,
+      `${basePath}/a.md`,
+      "main"
+    );
+  });
+
+  it("uses the base path itself when the relative path is empty", async () => {
+    const inner: IGitHubClient = {
+      fetchContent: vi.fn().mockResolvedValue(ok([])),
+      decodeBase64Content: vi.fn(),
+    };
+    const client = new ScopedGitHubClient(inner, basePath);
+
+    await client.fetchContent(owner, repo, "");
+
+    expect(inner.fetchContent).toHaveBeenCalledWith(
+      owner,
+      repo,
+      basePath,
+      undefined
+    );
+  });
+
+  it("strips the base path from returned file paths", async () => {
+    const inner: IGitHubClient = {
+      fetchContent: vi.fn().mockResolvedValue(ok(makeFile(`${basePath}/a.md`))),
+      decodeBase64Content: vi.fn(),
+    };
+    const client = new ScopedGitHubClient(inner, basePath);
+
+    const result = await client.fetchContent(owner, repo, "a.md");
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk() && !Array.isArray(result.value)) {
+      expect(result.value.path).toBe("a.md");
+    }
+  });
+
+  it("strips the base path from returned directory items", async () => {
+    const items: GitHubDirectoryItem[] = [
+      {
+        name: "a.md",
+        path: `${basePath}/a.md`,
+        sha: "sha",
+        size: 1,
+        url: "",
+        html_url: "",
+        git_url: "",
+        download_url: null,
+        type: "file",
+        _links: { self: "", git: "", html: "" },
+      },
+    ];
+    const inner: IGitHubClient = {
+      fetchContent: vi.fn().mockResolvedValue(ok(items)),
+      decodeBase64Content: vi.fn(),
+    };
+    const client = new ScopedGitHubClient(inner, basePath);
+
+    const result = await client.fetchContent(owner, repo, "");
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk() && Array.isArray(result.value)) {
+      expect(result.value[0].path).toBe("a.md");
+    }
   });
 });

--- a/policy/frontend/src/lib/github/ScopedGitHubClient.ts
+++ b/policy/frontend/src/lib/github/ScopedGitHubClient.ts
@@ -1,0 +1,76 @@
+import type { Result } from "neverthrow";
+import type { HttpError } from "../errors";
+import type {
+  GitHubDirectoryItem,
+  GitHubFile,
+  IGitHubClient,
+} from "./IGitHubClient";
+
+/**
+ * Normalize a target path env value into a repo-relative prefix without
+ * leading/trailing slashes (e.g. "/docs/policies/" -> "docs/policies").
+ */
+export function normalizeTargetPath(targetPath?: string): string {
+  if (!targetPath) return "";
+  return targetPath.trim().replace(/^\/+|\/+$/g, "");
+}
+
+/**
+ * Decorates an IGitHubClient so that all reads are confined to a subdirectory
+ * of the repository. Requests are prefixed with the base path, and repo-absolute
+ * paths returned by the GitHub API are stripped back to base-relative paths so
+ * that the rest of the app never needs to know the full path.
+ */
+export class ScopedGitHubClient implements IGitHubClient {
+  private readonly basePath: string;
+
+  constructor(
+    private readonly inner: IGitHubClient,
+    basePath: string
+  ) {
+    this.basePath = normalizeTargetPath(basePath);
+  }
+
+  private toRepoPath(path: string): string {
+    const relative = path.replace(/^\/+/, "");
+    if (!this.basePath) return relative;
+    return relative ? `${this.basePath}/${relative}` : this.basePath;
+  }
+
+  private toRelativePath(repoPath: string): string {
+    if (!this.basePath) return repoPath;
+    if (repoPath === this.basePath) return "";
+    const prefix = `${this.basePath}/`;
+    return repoPath.startsWith(prefix)
+      ? repoPath.slice(prefix.length)
+      : repoPath;
+  }
+
+  async fetchContent(
+    owner: string,
+    repo: string,
+    path = "",
+    ref?: string
+  ): Promise<Result<GitHubFile | GitHubDirectoryItem[], HttpError>> {
+    const result = await this.inner.fetchContent(
+      owner,
+      repo,
+      this.toRepoPath(path),
+      ref
+    );
+
+    return result.map((value) => {
+      if (Array.isArray(value)) {
+        return value.map((item) => ({
+          ...item,
+          path: this.toRelativePath(item.path),
+        }));
+      }
+      return { ...value, path: this.toRelativePath(value.path) };
+    });
+  }
+
+  decodeBase64Content(base64String: string): Result<string, HttpError> {
+    return this.inner.decodeBase64Content(base64String);
+  }
+}

--- a/policy/frontend/src/lib/github/factory.ts
+++ b/policy/frontend/src/lib/github/factory.ts
@@ -1,6 +1,7 @@
 import { CachedGitHubClient } from "./CachedGitHubClient";
 import type { IGitHubClient } from "./IGitHubClient";
 import { MockGitHubClient } from "./MockGitHubClient";
+import { ScopedGitHubClient, normalizeTargetPath } from "./ScopedGitHubClient";
 
 export function createGitHubClient(token?: string): IGitHubClient {
   const useMock = import.meta.env.VITE_USE_MOCK_GITHUB_CLIENT === "true";
@@ -9,5 +10,14 @@ export function createGitHubClient(token?: string): IGitHubClient {
     return new MockGitHubClient();
   }
 
-  return new CachedGitHubClient(token);
+  const client = new CachedGitHubClient(token);
+
+  const targetPath = normalizeTargetPath(
+    import.meta.env.VITE_GITHUB_TARGET_PATH
+  );
+  if (targetPath) {
+    return new ScopedGitHubClient(client, targetPath);
+  }
+
+  return client;
 }

--- a/policy/frontend/src/lib/github/index.ts
+++ b/policy/frontend/src/lib/github/index.ts
@@ -11,5 +11,9 @@ export type {
 export { GitHubClient } from "./GitHubClient";
 export { CachedGitHubClient } from "./CachedGitHubClient";
 export { MockGitHubClient } from "./MockGitHubClient";
+export {
+  ScopedGitHubClient,
+  normalizeTargetPath,
+} from "./ScopedGitHubClient";
 export { createGitHubClient } from "./factory";
 export { decodeBase64Content } from "./GitHubClient";

--- a/policy/frontend/src/vite-env.d.ts
+++ b/policy/frontend/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
     readonly VITE_API_BASE_URL?: string
     readonly VITE_GITHUB_REPO_OWNER: string
     readonly VITE_GITHUB_REPO_NAME: string
+    readonly VITE_GITHUB_TARGET_PATH?: string
     readonly VITE_SITE_NAME: string
     readonly VITE_SITE_LOGO_URL: string
     readonly VITE_FAVICON_URL?: string


### PR DESCRIPTION
# 変更の概要
いどばた政策(policy)で、閲覧・編集・PR 作成の対象をリポジトリ内の特定サブフォルダ以下に限定できるようにしました。`GITHUB_TARGET_PATH` 環境変数で対象フォルダを指定します（例: `GITHUB_TARGET_PATH=docs/policies`）。未設定(空)の場合は従来どおりリポジトリ全体が対象で、完全に後方互換です。

読み書きの両方を制限します。

- **書き込み(backend)**: `policy/backend` に `GITHUB_TARGET_PATH` を追加。`upsertFile` はフロントから渡される（フォルダ相対の）`filePath` に対象パスを前置してコミットするため、フォルダ外へは書き込めません。`..` によるエスケープは拒否します。
  ```ts
  // config.ts
  export const GITHUB_TARGET_PATH = (process.env.GITHUB_TARGET_PATH || "").trim().replace(/^\/+|\/+$/g, "");
  // upsertFile.ts
  const fullPath = resolveTargetPath(filePath); // GITHUB_TARGET_PATH/<relative>, ".." は throw
  ```
- **閲覧(frontend)**: フロントは GitHub API を直接読むため、`ScopedGitHubClient` デコレータを追加。リクエスト時に対象パスを前置し、GitHub が返すリポジトリ絶対パスを対象フォルダ相対パスに戻します。これによりアプリ本体（URL・パンくず・リンク・チャットの `filePath`）はフルパスを意識せず、フォルダ内だけを閲覧できます。
  ```ts
  // factory.ts
  const targetPath = normalizeTargetPath(import.meta.env.VITE_GITHUB_TARGET_PATH);
  return targetPath ? new ScopedGitHubClient(new CachedGitHubClient(token), targetPath) : new CachedGitHubClient(token);
  ```

`docker-compose.yml` は backend が `.env` を env_file 経由で読み込むため自動反映され、frontend には `VITE_GITHUB_TARGET_PATH=${GITHUB_TARGET_PATH}` のマッピングを追加しました（既存の `GITHUB_TARGET_OWNER` 等と同じパターン）。`.env.template` / `docs/development-setup.md` にも説明を追記。

なおモッククライアント(`VITE_USE_MOCK_GITHUB_CLIENT=true`)使用時はスコープを適用しません（モックデータはフォルダ前置を持たないため）。

# スクリーンショット
UI コンポーネント自体の変更はありません（クライアントの取得パスの前置/除去のみ）。

# 変更の背景
policy モジュールをリポジトリ全体ではなく特定フォルダ（例: `docs/policies`）だけに向けて運用したい、という要望への対応です。

# 関連Issue
なし

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

Link to Devin session: https://app.devin.ai/sessions/a1ea854c2d4b4a57829881a768247c23
Requested by: @kuboon