### PR TITLE
ci: チェックワークフローで npm ci を使用する

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-      - run: npm install
+      - run: npm ci
       - name: check
         run: npm run check


### PR DESCRIPTION
# 変更の概要
GitHub Actions のチェックワークフローにおける依存関係のインストールを、`npm install` から `npm ci` に変更しました。

# スクリーンショット
UIの変更はないため、スクリーンショットはありません。

# 変更の背景
CIでは lockfile に基づいて依存関係を再現可能な状態でインストールするため、`npm ci` を使用します。

# 関連Issue
なし

# CLAへの同意
本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/idobata/blob/main/CLA.md)に同意することが必須です。

内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました